### PR TITLE
beta: auto-download, notifications, and scheduler hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,5 +25,7 @@ AUTH_PASSWORD=
 # How often to auto-scan for updates (in minutes, default: 6 hours)
 CRON_INTERVAL_MINUTES=360
 
-# Where to store the database and logs (use a Docker volume path in containers)
+# App data paths
+# For the bundled Docker Compose file, these resolve inside the container as /app/data and /app/logs
 DATA_DIR=./data
+LOG_DIR=./logs

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker Publish
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "beta" ]
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "main" ]
@@ -44,7 +44,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ steps.lowercase.outputs.repo_owner }}/repackarr
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=branch
+            type=raw,value=beta,enable=${{ github.ref == 'refs/heads/beta' }}
             type=semver,pattern={{version}}
 
       - name: Build and push Docker image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,28 +3,28 @@
 ## [0.1.2] - 2026-03-08
 
 ### Added
-- Auto-Download can now automatically grab the best matching release for eligible games.
-- A new notification center shows when automatic downloads succeed, fail, or are skipped.
-- You can now control Auto-Download globally or override it for each game in your library.
+- Auto-Download can now grab matching updates for you automatically.
+- A new notification center keeps you posted when automatic downloads succeed, fail, or are skipped.
+- You can now control Auto-Download for the whole library or per game.
 
 ### Changed
-- The Add Game flow is now clearer: choose **I Want This Game** to search right away, or **I Already Have It** to just start tracking it.
-- Scheduled scans now run once at startup and avoid overlapping runs, making background checks more reliable.
-- Version labels, scan progress, and update actions now feel more consistent across the app.
-- Recommended releases on the Dashboard now match the exact release Auto-Download would choose.
+- Adding a game is now clearer: choose **I Want This Game** to search right away, or **I Already Have It** to simply track it.
+- Scans now start automatically after launch and feel more reliable overall.
+- The app feels more consistent across update checks, progress, and version labels.
+- Dashboard recommendations now line up better with what Auto-Download would pick.
 
 ### Fixed
-- Error messages are cleaner and safer when something goes wrong.
-- Auto-download follow-up handling is more reliable during large scan runs.
+- Error messages are clearer when something goes wrong.
+- Auto-download follow-up handling is more reliable during bigger scan runs.
 
 ## [0.1.1] - 2026-03-04
 
 ### Added
 - Per-torrent download and upload speed limit controls
-- Speed limits are now loaded from qBittorrent on page open
-- Upload speed shown alongside download speed in torrent status
-- Turtle mode toggle to quickly throttle all speeds
-- In-app changelog viewer
+- Speed limits now load from qBittorrent when you open the page
+- Upload speed is shown alongside download speed in torrent status
+- A turtle mode toggle to quickly slow everything down
+- An in-app changelog viewer
 
 ### Changed
 - Torrent control buttons redesigned for a cleaner look

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.1.2] - 2026-03-08
+
+### Added
+- Auto-Download can now automatically grab the best matching release for eligible games.
+- A new notification center shows when automatic downloads succeed, fail, or are skipped.
+- You can now control Auto-Download globally or override it for each game in your library.
+
+### Changed
+- The Add Game flow is now clearer: choose **I Want This Game** to search right away, or **I Already Have It** to just start tracking it.
+- Scheduled scans now run once at startup and avoid overlapping runs, making background checks more reliable.
+- Version labels, scan progress, and update actions now feel more consistent across the app.
+- Recommended releases on the Dashboard now match the exact release Auto-Download would choose.
+
+### Fixed
+- Error messages are cleaner and safer when something goes wrong.
+- Auto-download follow-up handling is more reliable during large scan runs.
+
 ## [0.1.1] - 2026-03-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ All connection details are set via environment variables in your `.env` file:
 | `AUTH_USERNAME` | (None) | Enable Basic Auth for the UI |
 | `AUTH_PASSWORD` | (None) | Enable Basic Auth for the UI |
 | `DATA_DIR` | `/app/data` | Where the database is stored |
+| `LOG_DIR` | `/app/logs` | Where application log files are written |
 
 The following can also be changed directly from the **Settings** page in the UI:
 - **Ignored Keywords** — releases containing these keywords will be skipped globally.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ services:
       retries: 3
 ```
 
+Use `ghcr.io/yakrel/repackarr:latest` for the stable main build, or switch the tag to `ghcr.io/yakrel/repackarr:beta` when you want to test the current beta branch image.
+
 ### 4. Launch
 ```bash
 docker compose up -d

--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 [![Docker Image](https://img.shields.io/badge/docker-ghcr.io%2Fyakrel%2Frepackarr-blue?logo=docker)](https://ghcr.io/yakrel/repackarr)
 
-**Repackarr** is an automated manager for game repacks. It monitors your existing qBittorrent library, tracks updates through Prowlarr, and allows you to upgrade your games with a single click. Think of it as "Sonarr/Radarr" specifically tailored for the game repack community.
+**Repackarr** helps you keep your game repack library up to date. It reads what you already have in qBittorrent, checks Prowlarr for better or newer releases, and lets you either pick updates manually or automate the whole flow.
 
 ## How It Works
 
 ```
-1. Sync Library      →   Repackarr imports your games from qBittorrent and detects their current versions.
-2. Scan for Updates  →   Prowlarr indexers are searched on a schedule for newer releases of each game.
-3. One-Click Update  →   Found a newer version? Send the magnet directly to qBittorrent with a single click.
+1. Sync Library      →   Repackarr imports the games you already have in qBittorrent.
+2. Check for Updates →   It keeps looking for newer releases in the background and you can also scan anytime.
+3. Update Your Games →   Review releases on the Dashboard or turn on AutoDL for hands-off upgrades.
+4. Stay Informed     →   Notifications tell you when AutoDL succeeds, fails, or skips a game.
 ```
 
 ## Screenshots
@@ -26,15 +27,26 @@
 
 ## Features
 
-- **Automatic Library Sync**: Imports your existing games from qBittorrent automatically — no manual entry needed.
-- **Smart Version Detection**: Accurately reads the current version of each game from torrent titles and tracker pages, including all major repackers (FitGirl, DODI, ElAmigos, KaOs, and more).
-- **Scheduled Update Scanning**: Periodically searches your Prowlarr indexers for newer versions of every game in your library.
-- **Smart Filtering**: Automatically ignores mods, patches, soundtracks, console releases, and other non-game content so your dashboard stays clean.
-- **Game Covers & Metadata**: Displays game artwork and metadata fetched from IGDB, with autocomplete when adding games manually.
-- **One-Click Updates**: When a newer version is found, send it straight to qBittorrent with a single click.
-- **Flexible Monitoring**: Add a game silently (monitor only future updates) or immediately search for the latest version — your choice.
-- **Skip & Ignore**: Not interested in a specific release? Skip it or hide it permanently. Restore it anytime from the Blacklist tab.
-- **Scan History**: Every sync and update scan is logged. Review what was found, what was skipped, and why.
+- **Automatic Library Sync**: Pulls in the games you already manage in qBittorrent, so there is no big manual setup.
+- **Smart Version Detection**: Reads version info from torrent titles and tracker pages across the major repack sources.
+- **Automatic Update Checks**: Keeps an eye on your monitored games and looks for newer releases for you.
+- **Auto-Download When You Want It**: Turn AutoDL on for the whole library or fine-tune it per game.
+- **Notification Center**: See right away when an automatic download worked, failed, or was skipped.
+- **Game Covers & Metadata**: Adds artwork and cleaner game info with IGDB support.
+- **One-Click Updates**: Prefer manual control? Send a release to qBittorrent with one click.
+- **Flexible Add Modes**: Choose between “I Want This Game” and “I Already Have It” when adding a title.
+- **Skip & Ignore**: Hide releases you do not want and restore them later from the blacklist.
+- **Scan History**: Review what past syncs and update checks found.
+
+## Auto-Download & Notifications
+
+- Turn **AutoDL** on from the **Library** page when you want Repackarr to grab updates for you.
+- Leave it off if you prefer to review releases on the Dashboard first.
+- You can still override AutoDL for each game:
+  - **Use Global** → inherit the library-wide toggle
+  - **Always** → auto-download updates for this game even if the global toggle is off
+  - **Never** → keep this game manual even if the global toggle is on
+- Notifications in the top bar let you know when Repackarr downloads an update, cannot send one to qBittorrent, or skips a game that is already downloading.
 
 ## Getting Started (Docker)
 
@@ -64,7 +76,8 @@ services:
     restart: unless-stopped
     ports:
       - "8090:3000"
-    env_file: .env
+    env_file:
+      - .env
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
@@ -73,15 +86,16 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+      start_period: 10s
 ```
-
-Use `ghcr.io/yakrel/repackarr:latest` for the stable main build, or switch the tag to `ghcr.io/yakrel/repackarr:beta` when you want to test the current beta branch image.
 
 ### 4. Launch
 ```bash
 docker compose up -d
 ```
 Open `http://your-ip:8090` and hit **Sync Library** to get started.
+
+After startup, Repackarr refreshes your library and begins checking for updates automatically.
 
 ## Configuration
 
@@ -100,18 +114,26 @@ All connection details are set via environment variables in your `.env` file:
 | `CRON_INTERVAL_MINUTES` | `360` | How often to scan for updates (in minutes) |
 | `AUTH_USERNAME` | (None) | Enable Basic Auth for the UI |
 | `AUTH_PASSWORD` | (None) | Enable Basic Auth for the UI |
-| `DATA_DIR` | `/app/data` | Where the database is stored |
-| `LOG_DIR` | `/app/logs` | Where application log files are written |
+| `DATA_DIR` | `/app/data` | Where app data is stored. For the bundled Docker setup, set this to `./data` in your `.env`. |
+| `LOG_DIR` | `logs` | Where app logs are written. For the bundled Docker setup, set this to `./logs` in your `.env`. |
 
-The following can also be changed directly from the **Settings** page in the UI:
-- **Ignored Keywords** — releases containing these keywords will be skipped globally.
-- **Allowed Indexers** — restrict searches to specific Prowlarr indexers.
-- **Default Platform** — Windows, Linux, or macOS.
+The following controls are managed from the UI:
+
+- **Settings page**
+  - **Ignored Keywords** — releases containing these keywords will be skipped globally.
+  - **Allowed Indexers** — restrict searches to specific Prowlarr indexers.
+  - **Default Platform** — Windows, Linux, or macOS.
+- **Library page**
+  - **Global Auto-Download** — enable or disable automatic downloading for monitored games.
+  - **Per-game Auto-Download** — override the global AutoDL behavior for one title at a time.
+  - **Add Game Mode** — choose between immediate search/download flow or track-only monitoring when adding a game manually.
 
 ## Troubleshooting
 
 - **Games not found**: Try adjusting the "Search Query" for that game in the Library page to match how it appears on your indexer.
 - **Indexer not working**: The name in **Allowed Indexers** must match exactly what Prowlarr shows.
+- **Auto-download did not trigger**: Make sure AutoDL is enabled globally or for that specific game and that qBittorrent is reachable. If the game is already downloading, Repackarr will skip it and notify you.
+- **Need more detail?**: Check the log files in `LOG_DIR`.
 - **Database errors on startup**: Fix permissions with `chown -R 1000:1000 ./data`.
 - **Reverse proxy**: Works with Nginx Proxy Manager and Traefik using a standard WebSocket-enabled config.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - .env
     volumes:
       - ./data:/app/data
+      - ./logs:/app/logs
     environment:
       - TZ=Europe/Istanbul
     healthcheck:

--- a/drizzle/0001_shocking_christian_walker.sql
+++ b/drizzle/0001_shocking_christian_walker.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `notification` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`type` text NOT NULL,
+	`game_id` integer,
+	`game_title` text NOT NULL,
+	`message` text NOT NULL,
+	`is_read` integer DEFAULT false NOT NULL,
+	`created_at` text NOT NULL,
+	FOREIGN KEY (`game_id`) REFERENCES `game`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_notification_is_read` ON `notification` (`is_read`);--> statement-breakpoint
+CREATE INDEX `idx_notification_created_at` ON `notification` (`created_at`);--> statement-breakpoint
+ALTER TABLE `game` ADD `auto_download_enabled` integer;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,560 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7d020636-5ef4-4566-9616-142bb666ccf2",
+  "prevId": "2b4b66fc-02db-4416-914f-89952c85749f",
+  "tables": {
+    "app_setting": {
+      "name": "app_setting",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game": {
+      "name": "game",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "search_query": {
+          "name": "search_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_version_date": {
+          "name": "current_version_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'monitored'"
+        },
+        "platform_filter": {
+          "name": "platform_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Windows'"
+        },
+        "exclude_keywords": {
+          "name": "exclude_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_manual": {
+          "name": "is_manual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "qbit_synced_at": {
+          "name": "qbit_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_id": {
+          "name": "igdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "steam_app_id": {
+          "name": "steam_app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_name": {
+          "name": "raw_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "info_hash": {
+          "name": "info_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_download_enabled": {
+          "name": "auto_download_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_scanned_at": {
+          "name": "last_scanned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_game_title": {
+          "name": "idx_game_title",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ignored_release": {
+      "name": "ignored_release",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_title": {
+          "name": "release_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ignored_at": {
+          "name": "ignored_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ignored_release_game_id": {
+          "name": "idx_ignored_release_game_id",
+          "columns": [
+            "game_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ignored_release_game_id_game_id_fk": {
+          "name": "ignored_release_game_id_game_id_fk",
+          "tableFrom": "ignored_release",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification": {
+      "name": "notification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "game_title": {
+          "name": "game_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_notification_is_read": {
+          "name": "idx_notification_is_read",
+          "columns": [
+            "is_read"
+          ],
+          "isUnique": false
+        },
+        "idx_notification_created_at": {
+          "name": "idx_notification_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notification_game_id_game_id_fk": {
+          "name": "notification_game_id_game_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "release": {
+      "name": "release",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_title": {
+          "name": "raw_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parsed_version": {
+          "name": "parsed_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upload_date": {
+          "name": "upload_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexer": {
+          "name": "indexer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "magnet_url": {
+          "name": "magnet_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "info_url": {
+          "name": "info_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seeders": {
+          "name": "seeders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "leechers": {
+          "name": "leechers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grabs": {
+          "name": "grabs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_ignored": {
+          "name": "is_ignored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "found_at": {
+          "name": "found_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_release_game_id": {
+          "name": "idx_release_game_id",
+          "columns": [
+            "game_id"
+          ],
+          "isUnique": false
+        },
+        "idx_release_raw_title": {
+          "name": "idx_release_raw_title",
+          "columns": [
+            "raw_title"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "release_game_id_game_id_fk": {
+          "name": "release_game_id_game_id_fk",
+          "tableFrom": "release",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_log": {
+      "name": "scan_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "games_processed": {
+          "name": "games_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updates_found": {
+          "name": "updates_found",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'success'"
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skip_details": {
+          "name": "skip_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1771942155950,
       "tag": "0000_great_silverclaw",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1772784480397,
+      "tag": "0001_shocking_christian_walker",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "repackarr",
 	"private": true,
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
 		"@tailwindcss/vite": "^4.0.0",
 		"@types/better-sqlite3": "^7.6.13",
 		"@types/node": "^25.2.2",
-		"@types/node-cron": "^3.0.11",
 		"drizzle-kit": "^0.31.9",
 		"svelte": "^5.50.0",
 		"svelte-check": "^4.3.6",
@@ -34,7 +33,6 @@
 		"dotenv": "^17.2.4",
 		"drizzle-orm": "^0.45.1",
 		"lucide-svelte": "^0.563.0",
-		"node-cron": "^4.0.0",
 		"winston": "^3.19.0",
 		"winston-daily-rotate-file": "^5.0.0",
 		"zod": "^3.25.76"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       lucide-svelte:
         specifier: ^0.563.0
         version: 0.563.0(svelte@5.50.0)
-      node-cron:
-        specifier: ^4.0.0
-        version: 4.2.1
       winston:
         specifier: ^3.19.0
         version: 3.19.0
@@ -51,9 +48,6 @@ importers:
       '@types/node':
         specifier: ^25.2.2
         version: 25.2.2
-      '@types/node-cron':
-        specifier: ^3.0.11
-        version: 3.0.11
       drizzle-kit:
         specifier: ^0.31.9
         version: 0.31.9
@@ -880,9 +874,6 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/node-cron@3.0.11':
-    resolution: {integrity: sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==}
-
   '@types/node@25.2.2':
     resolution: {integrity: sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==}
 
@@ -1338,10 +1329,6 @@ packages:
   node-abi@3.87.0:
     resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
     engines: {node: '>=10'}
-
-  node-cron@4.2.1:
-    resolution: {integrity: sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==}
-    engines: {node: '>=6.0.0'}
 
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
@@ -2092,8 +2079,6 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/node-cron@3.0.11': {}
-
   '@types/node@25.2.2':
     dependencies:
       undici-types: 7.16.0
@@ -2454,8 +2439,6 @@ snapshots:
   node-abi@3.87.0:
     dependencies:
       semver: 7.7.4
-
-  node-cron@4.2.1: {}
 
   object-hash@3.0.0: {}
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,6 +5,17 @@ import { logger, logError } from '$lib/server/logger.js';
 import { building } from '$app/environment';
 import { timingSafeEqual, createHash } from 'crypto';
 
+function hashCredential(value: string): Buffer {
+	return createHash('sha256').update(value).digest();
+}
+
+function unauthorizedResponse(message: string): Response {
+	return new Response(message, {
+		status: 401,
+		headers: { 'WWW-Authenticate': 'Basic realm="Repackarr"' }
+	});
+}
+
 // Initialize application on server start
 if (!building) {
 	try {
@@ -26,28 +37,27 @@ export const handle: Handle = async ({ event, resolve }) => {
 		const auth = event.request.headers.get('authorization');
 
 		if (!auth || !auth.startsWith('Basic ')) {
-			return new Response('Authentication required', {
-				status: 401,
-				headers: { 'WWW-Authenticate': 'Basic realm="Repackarr"' }
-			});
+			return unauthorizedResponse('Authentication required');
 		}
 
-		const decoded = atob(auth.slice(6));
-		const [username, password] = decoded.split(':');
+		let decoded: string;
+		try {
+			decoded = atob(auth.slice(6));
+		} catch {
+			return unauthorizedResponse('Invalid credentials');
+		}
 
-		const validUser = timingSafeEqual(
-			Buffer.from(username ?? ''),
-			Buffer.from(settings.AUTH_USERNAME)
-		);
-		const expectedHash = createHash('sha256').update(settings.AUTH_PASSWORD).digest();
-		const actualHash = createHash('sha256').update(password ?? '').digest();
+		const separatorIndex = decoded.indexOf(':');
+		const username = separatorIndex === -1 ? decoded : decoded.slice(0, separatorIndex);
+		const password = separatorIndex === -1 ? '' : decoded.slice(separatorIndex + 1);
+
+		const validUser = timingSafeEqual(hashCredential(username), hashCredential(settings.AUTH_USERNAME));
+		const expectedHash = hashCredential(settings.AUTH_PASSWORD);
+		const actualHash = hashCredential(password);
 		const validPass = timingSafeEqual(expectedHash, actualHash);
 
 		if (!validUser || !validPass) {
-			return new Response('Invalid credentials', {
-				status: 401,
-				headers: { 'WWW-Authenticate': 'Basic realm="Repackarr"' }
-			});
+			return unauthorizedResponse('Invalid credentials');
 		}
 	}
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -35,7 +35,10 @@ export const handle: Handle = async ({ event, resolve }) => {
 		const decoded = atob(auth.slice(6));
 		const [username, password] = decoded.split(':');
 
-		const validUser = username === settings.AUTH_USERNAME;
+		const validUser = timingSafeEqual(
+			Buffer.from(username ?? ''),
+			Buffer.from(settings.AUTH_USERNAME)
+		);
 		const expectedHash = createHash('sha256').update(settings.AUTH_PASSWORD).digest();
 		const actualHash = createHash('sha256').update(password ?? '').digest();
 		const validPass = timingSafeEqual(expectedHash, actualHash);

--- a/src/lib/components/ui/NotificationPanel.svelte
+++ b/src/lib/components/ui/NotificationPanel.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	type Notification = {
+		id: number;
+		type: 'auto_download_success' | 'auto_download_failed' | 'auto_download_skipped';
+		gameId: number | null;
+		gameTitle: string;
+		message: string;
+		isRead: boolean;
+		createdAt: string;
+	};
+
+	let notifications = $state<Notification[]>([]);
+	let unreadCount = $state(0);
+	let panelOpen = $state(false);
+	let loading = $state(false);
+
+	async function fetchNotifications() {
+		try {
+			const resp = await fetch('/api/notifications');
+			if (resp.ok) {
+				const data = await resp.json();
+				notifications = data.notifications ?? [];
+				unreadCount = data.unreadCount ?? 0;
+			}
+		} catch { /* ignore */ }
+	}
+
+	async function markAllRead() {
+		try {
+			await fetch('/api/notifications/read', { method: 'POST' });
+			notifications = notifications.map((n) => ({ ...n, isRead: true }));
+			unreadCount = 0;
+		} catch { /* ignore */ }
+	}
+
+	function togglePanel() {
+		panelOpen = !panelOpen;
+		if (panelOpen && unreadCount > 0) {
+			// Mark all as read when opening
+			markAllRead();
+		}
+	}
+
+	function formatRelativeTime(dateStr: string): string {
+		const diff = Date.now() - Date.parse(dateStr);
+		const minutes = Math.floor(diff / 60000);
+		if (minutes < 1) return 'just now';
+		if (minutes < 60) return `${minutes}m ago`;
+		const hours = Math.floor(minutes / 60);
+		if (hours < 24) return `${hours}h ago`;
+		const days = Math.floor(hours / 24);
+		return `${days}d ago`;
+	}
+
+	function getNotificationIcon(type: Notification['type']): string {
+		if (type === 'auto_download_success') return '✅';
+		if (type === 'auto_download_failed') return '❌';
+		return '⚠️';
+	}
+
+	function getNotificationColor(type: Notification['type']): string {
+		if (type === 'auto_download_success') return 'text-emerald-400';
+		if (type === 'auto_download_failed') return 'text-red-400';
+		return 'text-amber-400';
+	}
+
+	function handleClickOutside(e: MouseEvent) {
+		const target = e.target as HTMLElement;
+		if (!target.closest('[data-notification-panel]')) {
+			panelOpen = false;
+		}
+	}
+
+	onMount(() => {
+		fetchNotifications();
+		const interval = setInterval(fetchNotifications, 10000);
+		document.addEventListener('click', handleClickOutside);
+		return () => {
+			clearInterval(interval);
+			document.removeEventListener('click', handleClickOutside);
+		};
+	});
+</script>
+
+<div class="relative" data-notification-panel>
+	<!-- Bell Button -->
+	<button
+		onclick={togglePanel}
+		class="relative p-2 rounded-lg text-slate-400 hover:text-white hover:bg-slate-700 transition-colors"
+		title="Notifications"
+		aria-label="Toggle notifications"
+	>
+		<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+				d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+		</svg>
+		{#if unreadCount > 0}
+			<span
+				class="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none"
+			>
+				{unreadCount > 99 ? '99+' : unreadCount}
+			</span>
+		{/if}
+	</button>
+
+	<!-- Dropdown Panel -->
+	{#if panelOpen}
+		<div
+			class="absolute right-0 top-full mt-2 w-80 bg-slate-800 border border-slate-700 rounded-xl shadow-2xl z-50 overflow-hidden"
+		>
+			<!-- Header -->
+			<div class="flex items-center justify-between px-4 py-3 border-b border-slate-700">
+				<h3 class="text-sm font-semibold text-white">Notifications</h3>
+				{#if notifications.length > 0}
+					<button
+						onclick={markAllRead}
+						class="text-xs text-slate-400 hover:text-purple-400 transition-colors"
+					>
+						Mark all read
+					</button>
+				{/if}
+			</div>
+
+			<!-- Notification List -->
+			<div class="max-h-96 overflow-y-auto">
+				{#if notifications.length === 0}
+					<div class="px-4 py-8 text-center text-slate-500 text-sm">
+						<svg class="w-8 h-8 mx-auto mb-2 opacity-40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+								d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+						</svg>
+						No notifications yet
+					</div>
+				{:else}
+					{#each notifications as notif (notif.id)}
+						<div
+							class="px-4 py-3 border-b border-slate-700/50 last:border-0 transition-colors
+								{!notif.isRead ? 'bg-slate-700/30' : ''}"
+						>
+							<div class="flex items-start gap-2">
+								<span class="text-base mt-0.5 shrink-0">{getNotificationIcon(notif.type)}</span>
+								<div class="flex-1 min-w-0">
+									<p class="text-xs font-medium {getNotificationColor(notif.type)} truncate">{notif.gameTitle}</p>
+									<p class="text-xs text-slate-300 mt-0.5 leading-relaxed">{notif.message}</p>
+									<p class="text-[10px] text-slate-500 mt-1">{formatRelativeTime(notif.createdAt)}</p>
+								</div>
+								{#if !notif.isRead}
+									<div class="w-2 h-2 rounded-full bg-purple-500 shrink-0 mt-1.5"></div>
+								{/if}
+							</div>
+						</div>
+					{/each}
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/ui/NotificationPanel.svelte
+++ b/src/lib/components/ui/NotificationPanel.svelte
@@ -14,7 +14,6 @@
 	let notifications = $state<Notification[]>([]);
 	let unreadCount = $state(0);
 	let panelOpen = $state(false);
-	let loading = $state(false);
 
 	async function fetchNotifications() {
 		try {

--- a/src/lib/server/autoDownload.ts
+++ b/src/lib/server/autoDownload.ts
@@ -249,12 +249,10 @@ export async function tryAutoDownloadForGame(gameId: number): Promise<AutoDownlo
 			}
 			await new Promise((r) => setTimeout(r, 1000));
 		}
-		if (metadataReceived) {
-			await qbitService.recheckTorrent(newHash);
-		} else {
+		if (!metadataReceived) {
 			logger.warn(`[Auto-Download] Metadata not received for '${game.title}' within 30s`);
-			await qbitService.recheckTorrent(newHash);
 		}
+		await qbitService.recheckTorrent(newHash);
 	}
 
 	// Update database atomically

--- a/src/lib/server/autoDownload.ts
+++ b/src/lib/server/autoDownload.ts
@@ -2,9 +2,9 @@ import { db, transaction } from './database.js';
 import { games, releases, notifications, appSettings } from './schema.js';
 import { eq, and, lt } from 'drizzle-orm';
 import { qbitService } from './qbit.js';
-import { compareVersions, estimateVersionConfidence } from './utils.js';
 import { logger } from './logger.js';
 import { extractMagnetHash } from './validators.js';
+import { rankGameReleases } from './releaseSelection.js';
 
 // qBittorrent states that indicate an active, in-progress download
 const ACTIVE_DOWNLOAD_STATES = new Set([
@@ -18,7 +18,6 @@ const ACTIVE_DOWNLOAD_STATES = new Set([
 	'moving'
 ]);
 
-const EPOCH_DATE = '1970-01-01T00:00:00.000Z';
 const METADATA_POLL_INTERVAL_MS = 1000;
 const METADATA_WAIT_TIMEOUT_MS = 10000;
 const AUTO_DOWNLOAD_CONCURRENCY = 3;
@@ -29,84 +28,6 @@ function isActivelyDownloading(state: string): boolean {
 
 function delay(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function getRecencyScore(uploadDate: string): number {
-	const ts = Date.parse(uploadDate);
-	if (!ts || isNaN(ts)) return 0;
-	const ageDays = (Date.now() - ts) / (1000 * 60 * 60 * 24);
-	return Math.max(0, Math.round(40 - ageDays * 0.9));
-}
-
-function getSeederScore(seeders: number | null): number {
-	if (!seeders || seeders <= 0) return 0;
-	const clamped = Math.min(seeders, 500);
-	return Math.round((Math.log10(clamped + 1) / Math.log10(501)) * 24);
-}
-
-function getGrabScore(grabs: number | null): number {
-	if (!grabs || grabs <= 0) return 0;
-	const clamped = Math.min(grabs, 1000);
-	return Math.round((Math.log10(clamped + 1) / Math.log10(1001)) * 10);
-}
-
-type AutoDownloadCandidate = {
-	release: typeof releases.$inferSelect;
-	score: number;
-	isTopCandidate: boolean; // true for new games with no owned version
-};
-
-function findBestCandidate(
-	gameReleases: Array<typeof releases.$inferSelect>,
-	game: typeof games.$inferSelect
-): AutoDownloadCandidate | null {
-	if (gameReleases.length === 0) return null;
-
-	const hasOwnedVersion = Boolean(
-		game.currentVersion &&
-			game.currentVersionDate &&
-			game.currentVersionDate !== EPOCH_DATE
-	);
-
-	// Find the latest version among all releases (for new-game "top candidate" logic)
-	let latestVersion: string | null = null;
-	for (const rel of gameReleases) {
-		if (!rel.parsedVersion) continue;
-		if (!latestVersion) {
-			latestVersion = rel.parsedVersion;
-			continue;
-		}
-		if (compareVersions(latestVersion, rel.parsedVersion) === -1) {
-			latestVersion = rel.parsedVersion;
-		}
-	}
-
-	const candidates: AutoDownloadCandidate[] = [];
-
-	for (const rel of gameReleases) {
-		const confidenceScore = Math.round((estimateVersionConfidence(rel.rawTitle, rel.parsedVersion) / 100) * 20);
-		const freshnessScore = getRecencyScore(rel.uploadDate);
-		const seederScore = getSeederScore(rel.seeders);
-		const grabScore = getGrabScore(rel.grabs);
-		const score = confidenceScore + freshnessScore + seederScore + grabScore;
-
-		if (hasOwnedVersion) {
-			// Only qualify if this release is newer than the owned version
-			if (!rel.parsedVersion) continue;
-			const cmp = compareVersions(game.currentVersion!, rel.parsedVersion);
-			if (cmp !== -1) continue; // not newer, skip
-			candidates.push({ release: rel, score, isTopCandidate: false });
-		} else {
-			// New game: only the top version candidate qualifies
-			if (!rel.parsedVersion || rel.parsedVersion !== latestVersion) continue;
-			candidates.push({ release: rel, score, isTopCandidate: true });
-		}
-	}
-
-	if (candidates.length === 0) return null;
-
-	// Return the highest scored candidate
-	return candidates.sort((a, b) => b.score - a.score)[0];
 }
 
 async function isAutoDownloadEnabledForGame(game: typeof games.$inferSelect): Promise<boolean> {
@@ -175,6 +96,8 @@ export type AutoDownloadResult = {
 	reason?: string;
 	releaseTitle?: string;
 	version?: string;
+	selectionReason?: string;
+	recommendationScore?: number;
 };
 
 /**
@@ -196,12 +119,16 @@ export async function tryAutoDownloadForGame(gameId: number): Promise<AutoDownlo
 		.where(and(eq(releases.gameId, gameId), eq(releases.isIgnored, false)))
 		.all();
 
-	const candidate = findBestCandidate(gameReleases, game);
-	if (!candidate) {
+	const { selectedRelease } = rankGameReleases(game, gameReleases);
+	if (!selectedRelease) {
 		return { success: false, skipped: true, reason: 'No qualifying release found' };
 	}
 
-	const { release } = candidate;
+	const release = selectedRelease;
+	const selectionReason = release.recommendationReason || 'Top-ranked auto-download candidate';
+	logger.info(
+		`[Auto-Download] Selected '${release.rawTitle}' for '${game.title}' (${selectionReason}; score: ${release.recommendationScore})`
+	);
 
 	// Check if the candidate version is the same as what we already have
 	if (release.parsedVersion && game.currentVersion === release.parsedVersion) {
@@ -209,7 +136,10 @@ export async function tryAutoDownloadForGame(gameId: number): Promise<AutoDownlo
 			success: false,
 			skipped: true,
 			reason: 'Already on this version',
-			version: release.parsedVersion
+			version: release.parsedVersion,
+			releaseTitle: release.rawTitle,
+			selectionReason,
+			recommendationScore: release.recommendationScore
 		};
 	}
 
@@ -226,7 +156,9 @@ export async function tryAutoDownloadForGame(gameId: number): Promise<AutoDownlo
 					skipped: true,
 					reason: 'Active download in progress',
 					releaseTitle: release.rawTitle,
-					version: release.parsedVersion ?? undefined
+					version: release.parsedVersion ?? undefined,
+					selectionReason,
+					recommendationScore: release.recommendationScore
 				};
 			}
 		} catch (err) {
@@ -241,7 +173,14 @@ export async function tryAutoDownloadForGame(gameId: number): Promise<AutoDownlo
 		const msg = `Failed to auto-download ${release.rawTitle} — no download link available.`;
 		logger.warn(`[Auto-Download] ${msg}`);
 		await createNotification('auto_download_failed', game.id, game.title, msg);
-		return { success: false, skipped: false, reason: 'No download URL', releaseTitle: release.rawTitle };
+		return {
+			success: false,
+			skipped: false,
+			reason: 'No download URL',
+			releaseTitle: release.rawTitle,
+			selectionReason,
+			recommendationScore: release.recommendationScore
+		};
 	}
 
 	// Remove old torrent from qBit (keep files on disk)
@@ -264,7 +203,9 @@ export async function tryAutoDownloadForGame(gameId: number): Promise<AutoDownlo
 			success: false,
 			skipped: false,
 			reason: 'qBittorrent add failed',
-			releaseTitle: release.rawTitle
+			releaseTitle: release.rawTitle,
+			selectionReason,
+			recommendationScore: release.recommendationScore
 		};
 	}
 
@@ -298,7 +239,14 @@ export async function tryAutoDownloadForGame(gameId: number): Promise<AutoDownlo
 		logger.error(`[Auto-Download] DB update failed after successful qBit add for '${game.title}': ${err}`);
 		const msg = `${release.rawTitle} was sent to qBittorrent but the database update failed. Please refresh.`;
 		await createNotification('auto_download_failed', game.id, game.title, msg);
-		return { success: false, skipped: false, reason: 'DB update failed', releaseTitle: release.rawTitle };
+		return {
+			success: false,
+			skipped: false,
+			reason: 'DB update failed',
+			releaseTitle: release.rawTitle,
+			selectionReason,
+			recommendationScore: release.recommendationScore
+		};
 	}
 
 	const versionStr = release.parsedVersion ? `v${release.parsedVersion}` : 'latest version';
@@ -310,7 +258,9 @@ export async function tryAutoDownloadForGame(gameId: number): Promise<AutoDownlo
 		success: true,
 		skipped: false,
 		releaseTitle: release.rawTitle,
-		version: release.parsedVersion ?? undefined
+		version: release.parsedVersion ?? undefined,
+		selectionReason,
+		recommendationScore: release.recommendationScore
 	};
 }
 

--- a/src/lib/server/autoDownload.ts
+++ b/src/lib/server/autoDownload.ts
@@ -1,0 +1,307 @@
+import { db, transaction } from './database.js';
+import { games, releases, notifications, appSettings } from './schema.js';
+import { eq, and } from 'drizzle-orm';
+import { qbitService } from './qbit.js';
+import { compareVersions, estimateVersionConfidence } from './utils.js';
+import { logger } from './logger.js';
+
+// qBittorrent states that indicate an active, in-progress download
+const ACTIVE_DOWNLOAD_STATES = new Set([
+	'downloading',
+	'stalledDL',
+	'checkingDL',
+	'allocating',
+	'metaDL',
+	'queuedDL',
+	'forcedDL',
+	'moving'
+]);
+
+const EPOCH_DATE = '1970-01-01T00:00:00.000Z';
+
+function extractMagnetHash(url: string): string | null {
+	const match = url.match(/btih:([a-fA-F0-9]{40})/i);
+	return match ? match[1].toLowerCase() : null;
+}
+
+function isActivelyDownloading(state: string): boolean {
+	return ACTIVE_DOWNLOAD_STATES.has(state);
+}
+
+function getRecencyScore(uploadDate: string): number {
+	const ts = Date.parse(uploadDate);
+	if (!ts || isNaN(ts)) return 0;
+	const ageDays = (Date.now() - ts) / (1000 * 60 * 60 * 24);
+	return Math.max(0, Math.round(40 - ageDays * 0.9));
+}
+
+function getSeederScore(seeders: number | null): number {
+	if (!seeders || seeders <= 0) return 0;
+	const clamped = Math.min(seeders, 500);
+	return Math.round((Math.log10(clamped + 1) / Math.log10(501)) * 24);
+}
+
+function getGrabScore(grabs: number | null): number {
+	if (!grabs || grabs <= 0) return 0;
+	const clamped = Math.min(grabs, 1000);
+	return Math.round((Math.log10(clamped + 1) / Math.log10(1001)) * 10);
+}
+
+type AutoDownloadCandidate = {
+	release: typeof releases.$inferSelect;
+	score: number;
+	isTopCandidate: boolean; // true for new games with no owned version
+};
+
+function findBestCandidate(
+	gameReleases: Array<typeof releases.$inferSelect>,
+	game: typeof games.$inferSelect
+): AutoDownloadCandidate | null {
+	if (gameReleases.length === 0) return null;
+
+	const hasOwnedVersion = Boolean(
+		game.currentVersion &&
+			game.currentVersionDate &&
+			game.currentVersionDate !== EPOCH_DATE
+	);
+
+	// Find the latest version among all releases (for new-game "top candidate" logic)
+	let latestVersion: string | null = null;
+	for (const rel of gameReleases) {
+		if (!rel.parsedVersion) continue;
+		if (!latestVersion) {
+			latestVersion = rel.parsedVersion;
+			continue;
+		}
+		if (compareVersions(latestVersion, rel.parsedVersion) === -1) {
+			latestVersion = rel.parsedVersion;
+		}
+	}
+
+	const candidates: AutoDownloadCandidate[] = [];
+
+	for (const rel of gameReleases) {
+		const confidenceScore = Math.round((estimateVersionConfidence(rel.rawTitle, rel.parsedVersion) / 100) * 20);
+		const freshnessScore = getRecencyScore(rel.uploadDate);
+		const seederScore = getSeederScore(rel.seeders);
+		const grabScore = getGrabScore(rel.grabs);
+		const score = confidenceScore + freshnessScore + seederScore + grabScore;
+
+		if (hasOwnedVersion) {
+			// Only qualify if this release is newer than the owned version
+			if (!rel.parsedVersion) continue;
+			const cmp = compareVersions(game.currentVersion!, rel.parsedVersion);
+			if (cmp !== -1) continue; // not newer, skip
+			candidates.push({ release: rel, score, isTopCandidate: false });
+		} else {
+			// New game: only the top version candidate qualifies
+			if (!rel.parsedVersion || rel.parsedVersion !== latestVersion) continue;
+			candidates.push({ release: rel, score, isTopCandidate: true });
+		}
+	}
+
+	if (candidates.length === 0) return null;
+
+	// Return the highest scored candidate
+	return candidates.sort((a, b) => b.score - a.score)[0];
+}
+
+async function isAutoDownloadEnabledForGame(game: typeof games.$inferSelect): Promise<boolean> {
+	// Per-game override takes precedence
+	if (game.autoDownloadEnabled !== null && game.autoDownloadEnabled !== undefined) {
+		return Boolean(game.autoDownloadEnabled);
+	}
+	// Fall back to global setting
+	const setting = db
+		.select()
+		.from(appSettings)
+		.where(eq(appSettings.key, 'autoDownload'))
+		.get();
+	return setting?.value === 'true';
+}
+
+async function createNotification(
+	type: 'auto_download_success' | 'auto_download_failed' | 'auto_download_skipped',
+	gameId: number,
+	gameTitle: string,
+	message: string
+): Promise<void> {
+	try {
+		db.insert(notifications).values({ type, gameId, gameTitle, message }).run();
+		// Auto-cleanup: delete read notifications older than 30 days
+		const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+		db.delete(notifications).where(
+			and(eq(notifications.isRead, true))
+		).run();
+	} catch (err) {
+		logger.warn(`Failed to create notification: ${err}`);
+	}
+}
+
+export type AutoDownloadResult = {
+	success: boolean;
+	skipped: boolean;
+	reason?: string;
+	releaseTitle?: string;
+	version?: string;
+};
+
+/**
+ * Attempts to auto-download the best qualifying release for a game.
+ * Returns a result object describing what happened.
+ */
+export async function tryAutoDownloadForGame(gameId: number): Promise<AutoDownloadResult> {
+	const game = db.select().from(games).where(eq(games.id, gameId)).get();
+	if (!game) return { success: false, skipped: true, reason: 'Game not found' };
+	if (game.status !== 'monitored') return { success: false, skipped: true, reason: 'Game not monitored' };
+
+	const enabled = await isAutoDownloadEnabledForGame(game);
+	if (!enabled) return { success: false, skipped: true, reason: 'Auto-download disabled' };
+
+	// Get all non-ignored releases for this game
+	const gameReleases = db
+		.select()
+		.from(releases)
+		.where(and(eq(releases.gameId, gameId), eq(releases.isIgnored, false)))
+		.all();
+
+	const candidate = findBestCandidate(gameReleases, game);
+	if (!candidate) {
+		return { success: false, skipped: true, reason: 'No qualifying release found' };
+	}
+
+	const { release } = candidate;
+
+	// Check if the candidate version is the same as what we already have
+	if (release.parsedVersion && game.currentVersion === release.parsedVersion) {
+		return {
+			success: false,
+			skipped: true,
+			reason: 'Already on this version',
+			version: release.parsedVersion
+		};
+	}
+
+	// Check for active download in qBittorrent
+	if (game.infoHash) {
+		try {
+			const torrent = await qbitService.getTorrent(game.infoHash);
+			if (torrent && isActivelyDownloading(torrent.state)) {
+				const msg = `New version ${release.parsedVersion ?? 'unknown'} found, but ${game.title} is currently downloading (${Math.round(torrent.progress * 100)}%). Click to switch versions.`;
+				logger.info(`[Auto-Download] Skipping ${game.title} — active download detected (state: ${torrent.state})`);
+				await createNotification('auto_download_skipped', game.id, game.title, msg);
+				return {
+					success: false,
+					skipped: true,
+					reason: 'Active download in progress',
+					releaseTitle: release.rawTitle,
+					version: release.parsedVersion ?? undefined
+				};
+			}
+		} catch (err) {
+			logger.warn(`[Auto-Download] Could not check qBit state for ${game.title}: ${err}`);
+			// Don't block auto-download if we can't check the state
+		}
+	}
+
+	// Validate download URL
+	const magnet = release.magnetUrl || release.infoUrl;
+	if (!magnet) {
+		const msg = `Failed to auto-download ${release.rawTitle} — no download link available.`;
+		logger.warn(`[Auto-Download] ${msg}`);
+		await createNotification('auto_download_failed', game.id, game.title, msg);
+		return { success: false, skipped: false, reason: 'No download URL', releaseTitle: release.rawTitle };
+	}
+
+	// Remove old torrent from qBit (keep files on disk)
+	if (game.infoHash) {
+		const removed = await qbitService.removeTorrent(game.infoHash);
+		if (removed) {
+			logger.info(`[Auto-Download] Removed old torrent for '${game.title}' (hash: ${game.infoHash})`);
+		} else {
+			logger.warn(`[Auto-Download] Could not remove old torrent for '${game.title}' — may already be gone`);
+		}
+	}
+
+	// Add new torrent to qBittorrent
+	const qbitSuccess = await qbitService.addTorrent(magnet);
+	if (!qbitSuccess) {
+		const msg = `Failed to send ${release.rawTitle} to qBittorrent. Please check your qBittorrent connection.`;
+		logger.error(`[Auto-Download] ${msg}`);
+		await createNotification('auto_download_failed', game.id, game.title, msg);
+		return {
+			success: false,
+			skipped: false,
+			reason: 'qBittorrent add failed',
+			releaseTitle: release.rawTitle
+		};
+	}
+
+	// Wait for metadata (up to 30s) and trigger recheck
+	const newHash = extractMagnetHash(magnet);
+	if (newHash) {
+		let metadataReceived = false;
+		for (let i = 0; i < 30; i++) {
+			const torrent = await qbitService.getTorrent(newHash);
+			if (torrent && torrent.total_size > 0) {
+				metadataReceived = true;
+				break;
+			}
+			await new Promise((r) => setTimeout(r, 1000));
+		}
+		if (metadataReceived) {
+			await qbitService.recheckTorrent(newHash);
+		} else {
+			logger.warn(`[Auto-Download] Metadata not received for '${game.title}' within 30s`);
+			await qbitService.recheckTorrent(newHash);
+		}
+	}
+
+	// Update database atomically
+	try {
+		transaction(() => {
+			db.update(games)
+				.set({
+					currentVersionDate: release.uploadDate,
+					...(release.parsedVersion ? { currentVersion: release.parsedVersion } : {})
+				})
+				.where(eq(games.id, game.id))
+				.run();
+			db.delete(releases).where(eq(releases.gameId, game.id)).run();
+		});
+	} catch (err) {
+		logger.error(`[Auto-Download] DB update failed after successful qBit add for '${game.title}': ${err}`);
+		const msg = `${release.rawTitle} was sent to qBittorrent but the database update failed. Please refresh.`;
+		await createNotification('auto_download_failed', game.id, game.title, msg);
+		return { success: false, skipped: false, reason: 'DB update failed', releaseTitle: release.rawTitle };
+	}
+
+	const versionStr = release.parsedVersion ? `v${release.parsedVersion}` : 'latest version';
+	const msg = `${game.title} ${versionStr} was automatically downloaded and added to qBittorrent.`;
+	logger.info(`[Auto-Download] ✅ ${msg}`);
+	await createNotification('auto_download_success', game.id, game.title, msg);
+
+	return {
+		success: true,
+		skipped: false,
+		releaseTitle: release.rawTitle,
+		version: release.parsedVersion ?? undefined
+	};
+}
+
+/**
+ * Attempts auto-download for multiple games (used after scan cycles).
+ * Returns count of successful downloads.
+ */
+export async function tryAutoDownloadForGames(gameIds: number[]): Promise<number> {
+	let downloadCount = 0;
+	for (const gameId of gameIds) {
+		try {
+			const result = await tryAutoDownloadForGame(gameId);
+			if (result.success) downloadCount++;
+		} catch (err) {
+			logger.error(`[Auto-Download] Unexpected error for gameId ${gameId}: ${err}`);
+		}
+	}
+	return downloadCount;
+}

--- a/src/lib/server/autoDownload.ts
+++ b/src/lib/server/autoDownload.ts
@@ -1,6 +1,6 @@
 import { db, transaction } from './database.js';
 import { games, releases, notifications, appSettings } from './schema.js';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, lt } from 'drizzle-orm';
 import { qbitService } from './qbit.js';
 import { compareVersions, estimateVersionConfidence } from './utils.js';
 import { logger } from './logger.js';
@@ -131,7 +131,7 @@ async function createNotification(
 		// Auto-cleanup: delete read notifications older than 30 days
 		const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
 		db.delete(notifications).where(
-			and(eq(notifications.isRead, true))
+			and(eq(notifications.isRead, true), lt(notifications.createdAt, cutoff))
 		).run();
 	} catch (err) {
 		logger.warn(`Failed to create notification: ${err}`);

--- a/src/lib/server/autoDownload.ts
+++ b/src/lib/server/autoDownload.ts
@@ -4,6 +4,7 @@ import { eq, and, lt } from 'drizzle-orm';
 import { qbitService } from './qbit.js';
 import { compareVersions, estimateVersionConfidence } from './utils.js';
 import { logger } from './logger.js';
+import { extractMagnetHash } from './validators.js';
 
 // qBittorrent states that indicate an active, in-progress download
 const ACTIVE_DOWNLOAD_STATES = new Set([
@@ -18,11 +19,6 @@ const ACTIVE_DOWNLOAD_STATES = new Set([
 ]);
 
 const EPOCH_DATE = '1970-01-01T00:00:00.000Z';
-
-function extractMagnetHash(url: string): string | null {
-	const match = url.match(/btih:([a-fA-F0-9]{40})/i);
-	return match ? match[1].toLowerCase() : null;
-}
 
 function isActivelyDownloading(state: string): boolean {
 	return ACTIVE_DOWNLOAD_STATES.has(state);

--- a/src/lib/server/autoDownload.ts
+++ b/src/lib/server/autoDownload.ts
@@ -19,9 +19,16 @@ const ACTIVE_DOWNLOAD_STATES = new Set([
 ]);
 
 const EPOCH_DATE = '1970-01-01T00:00:00.000Z';
+const METADATA_POLL_INTERVAL_MS = 1000;
+const METADATA_WAIT_TIMEOUT_MS = 10000;
+const AUTO_DOWNLOAD_CONCURRENCY = 3;
 
 function isActivelyDownloading(state: string): boolean {
 	return ACTIVE_DOWNLOAD_STATES.has(state);
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function getRecencyScore(uploadDate: string): number {
@@ -134,6 +141,34 @@ async function createNotification(
 	}
 }
 
+async function waitForMetadataAndRecheck(hash: string, gameTitle: string): Promise<void> {
+	const maxAttempts = Math.ceil(METADATA_WAIT_TIMEOUT_MS / METADATA_POLL_INTERVAL_MS);
+	let metadataReceived = false;
+
+	for (let attempt = 0; attempt < maxAttempts; attempt++) {
+		const torrent = await qbitService.getTorrent(hash);
+		if (torrent && torrent.total_size > 0) {
+			metadataReceived = true;
+			break;
+		}
+
+		if (attempt < maxAttempts - 1) {
+			await delay(METADATA_POLL_INTERVAL_MS);
+		}
+	}
+
+	if (!metadataReceived) {
+		logger.warn(
+			`[Auto-Download] Metadata not received for '${gameTitle}' within ${METADATA_WAIT_TIMEOUT_MS / 1000}s; requesting recheck anyway`
+		);
+	}
+
+	const recheckStarted = await qbitService.recheckTorrent(hash);
+	if (!recheckStarted) {
+		logger.warn(`[Auto-Download] Failed to trigger recheck for '${gameTitle}' (hash: ${hash})`);
+	}
+}
+
 export type AutoDownloadResult = {
 	success: boolean;
 	skipped: boolean;
@@ -233,22 +268,12 @@ export async function tryAutoDownloadForGame(gameId: number): Promise<AutoDownlo
 		};
 	}
 
-	// Wait for metadata (up to 30s) and trigger recheck
+	// Kick off metadata polling/recheck without blocking the scan/request lifecycle.
 	const newHash = extractMagnetHash(magnet);
 	if (newHash) {
-		let metadataReceived = false;
-		for (let i = 0; i < 30; i++) {
-			const torrent = await qbitService.getTorrent(newHash);
-			if (torrent && torrent.total_size > 0) {
-				metadataReceived = true;
-				break;
-			}
-			await new Promise((r) => setTimeout(r, 1000));
-		}
-		if (!metadataReceived) {
-			logger.warn(`[Auto-Download] Metadata not received for '${game.title}' within 30s`);
-		}
-		await qbitService.recheckTorrent(newHash);
+		void waitForMetadataAndRecheck(newHash, game.title).catch((err) => {
+			logger.warn(`[Auto-Download] Post-add processing failed for '${game.title}': ${String(err)}`);
+		});
 	}
 
 	// Update database atomically
@@ -295,13 +320,20 @@ export async function tryAutoDownloadForGame(gameId: number): Promise<AutoDownlo
  */
 export async function tryAutoDownloadForGames(gameIds: number[]): Promise<number> {
 	let downloadCount = 0;
-	for (const gameId of gameIds) {
-		try {
-			const result = await tryAutoDownloadForGame(gameId);
-			if (result.success) downloadCount++;
-		} catch (err) {
-			logger.error(`[Auto-Download] Unexpected error for gameId ${gameId}: ${err}`);
-		}
+	for (let i = 0; i < gameIds.length; i += AUTO_DOWNLOAD_CONCURRENCY) {
+		const chunk = gameIds.slice(i, i + AUTO_DOWNLOAD_CONCURRENCY);
+		const results = await Promise.all(
+			chunk.map(async (gameId) => {
+				try {
+					return await tryAutoDownloadForGame(gameId);
+				} catch (err) {
+					logger.error(`[Auto-Download] Unexpected error for gameId ${gameId}: ${err}`);
+					return null;
+				}
+			})
+		);
+
+		downloadCount += results.filter((result) => result?.success).length;
 	}
 	return downloadCount;
 }

--- a/src/lib/server/autoDownload.ts
+++ b/src/lib/server/autoDownload.ts
@@ -259,10 +259,16 @@ export async function tryAutoDownloadForGame(gameId: number): Promise<AutoDownlo
 
 	// Update database atomically
 	try {
+		const nextRawName = release.rawTitle;
+		const nextInfoHash = newHash ?? null;
+		const nextSourceUrl = release.infoUrl ?? null;
 		transaction(() => {
 			db.update(games)
 				.set({
 					currentVersionDate: release.uploadDate,
+					rawName: nextRawName,
+					infoHash: nextInfoHash,
+					sourceUrl: nextSourceUrl,
 					...(release.parsedVersion ? { currentVersion: release.parsedVersion } : {})
 				})
 				.where(eq(games.id, game.id))

--- a/src/lib/server/manager.ts
+++ b/src/lib/server/manager.ts
@@ -6,6 +6,7 @@ import { searchForGame, type SkipInfo } from './prowlarr.js';
 import { progressManager } from './progress.js';
 import { logger, logError } from './logger.js';
 import { compareVersions } from './utils.js';
+import { tryAutoDownloadForGames } from './autoDownload.js';
 
 export async function runSyncLibrary(currentProgress?: { start: number, total: number }): Promise<number> {
     logger.info('Starting library sync from qBittorrent...');
@@ -110,6 +111,22 @@ export async function runSearchUpdates(currentProgress?: { start: number, total:
 
     } catch (error) {
         logError('Update search failed', error);
+    }
+
+    // Auto-download: attempt for all monitored games that now have qualifying releases
+    const monitoredGameIds = db
+        .select({ id: games.id })
+        .from(games)
+        .where(eq(games.status, 'monitored'))
+        .all()
+        .map((g) => g.id);
+
+    if (monitoredGameIds.length > 0) {
+        logger.info(`[Auto-Download] Running auto-download check for ${monitoredGameIds.length} game(s)...`);
+        const downloaded = await tryAutoDownloadForGames(monitoredGameIds);
+        if (downloaded > 0) {
+            logger.info(`[Auto-Download] Auto-downloaded ${downloaded} game(s).`);
+        }
     }
 
     const duration = (Date.now() - startTime) / 1000;

--- a/src/lib/server/manager.ts
+++ b/src/lib/server/manager.ts
@@ -128,20 +128,27 @@ export async function runSearchUpdates(
         fatalError = error;
     }
 
-    // Auto-download: attempt for all monitored games that now have qualifying releases
-    const monitoredGameIds = db
-        .select({ id: games.id })
-        .from(games)
-        .where(eq(games.status, 'monitored'))
-        .all()
-        .map((g) => g.id);
+    try {
+        // Auto-download: attempt for all monitored games that now have qualifying releases
+        const monitoredGameIds = db
+            .select({ id: games.id })
+            .from(games)
+            .where(eq(games.status, 'monitored'))
+            .all()
+            .map((g) => g.id);
 
-    if (monitoredGameIds.length > 0) {
-        logger.info(`[Auto-Download] Running auto-download check for ${monitoredGameIds.length} game(s)...`);
-        const downloaded = await tryAutoDownloadForGames(monitoredGameIds);
-        if (downloaded > 0) {
-            logger.info(`[Auto-Download] Auto-downloaded ${downloaded} game(s).`);
+        if (monitoredGameIds.length > 0) {
+            logger.info(`[Auto-Download] Running auto-download check for ${monitoredGameIds.length} game(s)...`);
+            const downloaded = await tryAutoDownloadForGames(monitoredGameIds);
+            if (downloaded > 0) {
+                logger.info(`[Auto-Download] Auto-downloaded ${downloaded} game(s).`);
+            }
         }
+    } catch (error) {
+        logError('Auto-download step failed', error);
+        scanDetails.push(
+            `Auto-download step: ${error instanceof Error ? error.message : String(error)}`
+        );
     }
 
     const duration = (Date.now() - startTime) / 1000;

--- a/src/lib/server/manager.ts
+++ b/src/lib/server/manager.ts
@@ -8,7 +8,14 @@ import { logger, logError } from './logger.js';
 import { compareVersions } from './utils.js';
 import { tryAutoDownloadForGames } from './autoDownload.js';
 
-export async function runSyncLibrary(currentProgress?: { start: number, total: number }): Promise<number> {
+type ScanOptions = {
+	throwOnError?: boolean;
+};
+
+export async function runSyncLibrary(
+	currentProgress?: { start: number; total: number },
+	options: ScanOptions = {}
+): Promise<number> {
     logger.info('Starting library sync from qBittorrent...');
     try {
         if (currentProgress) {
@@ -27,16 +34,23 @@ export async function runSyncLibrary(currentProgress?: { start: number, total: n
         return synced;
     } catch (error) {
         logError('Library sync failed', error);
+        if (options.throwOnError) {
+            throw error;
+        }
         return 0;
     }
 }
 
-export async function runSearchUpdates(currentProgress?: { start: number, total: number }): Promise<number> {
+export async function runSearchUpdates(
+	currentProgress?: { start: number; total: number },
+	options: ScanOptions = {}
+): Promise<number> {
     const startTime = Date.now();
     logger.info('Starting Prowlarr update search...');
     let scanned = 0, totalFound = 0, totalAdded = 0;
     const scanDetails: string[] = [];
     const allSkipped: Array<{ game: string; game_id: number; items: SkipInfo[] }> = [];
+    let fatalError: unknown = null;
 
     try {
         const monitoredGames = db.select().from(games).where(eq(games.status, 'monitored')).all();
@@ -111,6 +125,7 @@ export async function runSearchUpdates(currentProgress?: { start: number, total:
 
     } catch (error) {
         logError('Update search failed', error);
+        fatalError = error;
     }
 
     // Auto-download: attempt for all monitored games that now have qualifying releases
@@ -134,11 +149,19 @@ export async function runSearchUpdates(currentProgress?: { start: number, total:
         db.insert(scanLogs).values({
             startedAt: new Date(startTime).toISOString(), durationSeconds: duration,
             gamesProcessed: scanned, updatesFound: totalAdded,
-            status: scanDetails.length ? 'partial_success' : 'success',
-            details: JSON.stringify({ total_results_found: totalFound, errors: scanDetails.slice(0, 10) }),
+            status: fatalError ? 'failed' : scanDetails.length ? 'partial_success' : 'success',
+            details: JSON.stringify({
+                total_results_found: totalFound,
+                errors: scanDetails.slice(0, 10),
+                fatal_error: fatalError instanceof Error ? fatalError.message : fatalError ? String(fatalError) : null
+            }),
             skipDetails: allSkipped.length ? JSON.stringify(allSkipped) : null
         }).run();
     } catch (e) { logError('Failed to save scan log', e); }
+
+    if (fatalError && options.throwOnError) {
+        throw fatalError;
+    }
 
     return scanned;
 }

--- a/src/lib/server/releaseSelection.ts
+++ b/src/lib/server/releaseSelection.ts
@@ -1,0 +1,225 @@
+import { games, releases } from './schema.js';
+import { compareVersions, estimateVersionConfidence } from './utils.js';
+
+const EPOCH_DATE = '1970-01-01T00:00:00.000Z';
+
+type GameRecord = typeof games.$inferSelect;
+type ReleaseRecord = typeof releases.$inferSelect;
+
+export type ReleaseVersionState = 'newer' | 'same' | 'older' | 'unknown';
+
+export type RankedRelease = ReleaseRecord & {
+	confidenceScore: number;
+	freshnessScore: number;
+	popularityScore: number;
+	seederScore: number;
+	grabScore: number;
+	recommendationScore: number;
+	versionState: ReleaseVersionState;
+	hasDownloadLink: boolean;
+	isAutoDownloadCandidate: boolean;
+	isRecommended: boolean;
+	recommendationTier: 'high' | 'low';
+	recommendationReason: string;
+};
+
+export type GameReleaseSelection = {
+	rankedReleases: RankedRelease[];
+	selectedRelease: RankedRelease | null;
+};
+
+function toTimestamp(value: string): number {
+	const ts = Date.parse(value);
+	return isNaN(ts) ? 0 : ts;
+}
+
+function normalizeMetric(value: number | null | undefined): number | null {
+	if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return null;
+	return Math.trunc(value);
+}
+
+function getRecencyScore(uploadDate: string): number {
+	const ts = toTimestamp(uploadDate);
+	if (!ts) return 0;
+
+	const ageDays = (Date.now() - ts) / (1000 * 60 * 60 * 24);
+	return Math.max(0, Math.round(40 - ageDays * 0.9));
+}
+
+function getSeederScore(seeders: number | null): number {
+	if (!seeders || seeders <= 0) return 0;
+	const clamped = Math.min(seeders, 500);
+	return Math.round((Math.log10(clamped + 1) / Math.log10(501)) * 24);
+}
+
+function getGrabScore(grabs: number | null): number {
+	if (!grabs || grabs <= 0) return 0;
+	const clamped = Math.min(grabs, 1000);
+	return Math.round((Math.log10(clamped + 1) / Math.log10(1001)) * 10);
+}
+
+function hasOwnedVersion(game: GameRecord): boolean {
+	return Boolean(
+		game.currentVersion &&
+			game.currentVersionDate &&
+			game.currentVersionDate !== EPOCH_DATE
+	);
+}
+
+function getLatestParsedVersion(gameReleases: ReleaseRecord[]): string | null {
+	let latestVersion: string | null = null;
+
+	for (const release of gameReleases) {
+		if (!release.parsedVersion) continue;
+		if (!latestVersion) {
+			latestVersion = release.parsedVersion;
+			continue;
+		}
+
+		if (compareVersions(latestVersion, release.parsedVersion) === -1) {
+			latestVersion = release.parsedVersion;
+		}
+	}
+
+	return latestVersion;
+}
+
+function getVersionState(
+	currentVersion: string | null,
+	parsedVersion: string | null
+): ReleaseVersionState {
+	if (!parsedVersion) return 'unknown';
+	if (!currentVersion) return 'unknown';
+
+	const cmp = compareVersions(currentVersion, parsedVersion);
+	if (cmp === -1) return 'newer';
+	if (cmp === 0) return 'same';
+	if (cmp === 1) return 'older';
+	return 'unknown';
+}
+
+function getVersionScore(
+	hasCurrentVersion: boolean,
+	versionState: ReleaseVersionState,
+	isAutoDownloadCandidate: boolean,
+	parsedVersion: string | null
+): number {
+	if (isAutoDownloadCandidate) return 40;
+	if (!hasCurrentVersion) return parsedVersion ? 12 : 8;
+	if (versionState === 'same') return 22;
+	if (versionState === 'unknown') return 12;
+	return 0;
+}
+
+function buildRecommendationReason(
+	release: RankedRelease,
+	gameHasOwnedVersion: boolean
+): string {
+	const label = gameHasOwnedVersion ? 'Newer version' : 'Best match';
+
+	return [
+		label,
+		release.seeders !== null ? `${release.seeders} seeders` : null,
+		release.leechers !== null ? `${release.leechers} leechers` : null,
+		release.grabs !== null ? `${release.grabs} grabs` : null
+	]
+		.filter((part): part is string => Boolean(part))
+		.join(' • ');
+}
+
+export function rankGameReleases(
+	game: GameRecord,
+	gameReleases: ReleaseRecord[]
+): GameReleaseSelection {
+	const gameHasOwnedVersion = hasOwnedVersion(game);
+	const currentVersion = gameHasOwnedVersion ? game.currentVersion : null;
+	const latestParsedVersion = getLatestParsedVersion(gameReleases);
+
+	const scoredReleases = gameReleases
+		.map((release) => {
+			const seeders = normalizeMetric(release.seeders);
+			const grabs = normalizeMetric(release.grabs);
+			const seederScore = getSeederScore(seeders);
+			const grabScore = getGrabScore(grabs);
+			const versionState = getVersionState(currentVersion, release.parsedVersion);
+			const hasDownloadLink = Boolean(release.magnetUrl || release.infoUrl);
+			const isAutoDownloadCandidate = hasDownloadLink && (
+				gameHasOwnedVersion
+					? versionState === 'newer'
+					: Boolean(
+							release.parsedVersion &&
+							latestParsedVersion &&
+							compareVersions(latestParsedVersion, release.parsedVersion) === 0
+						)
+			);
+			const confidenceScore = Math.round(
+				(estimateVersionConfidence(release.rawTitle, release.parsedVersion) / 100) * 20
+			);
+			const freshnessScore = getRecencyScore(release.uploadDate);
+			const popularityScore = seederScore + grabScore;
+			const versionScore = getVersionScore(
+				gameHasOwnedVersion,
+				versionState,
+				isAutoDownloadCandidate,
+				release.parsedVersion
+			);
+
+			return {
+				...release,
+				confidenceScore,
+				freshnessScore,
+				popularityScore,
+				seederScore,
+				grabScore,
+				recommendationScore: versionScore + confidenceScore + freshnessScore + popularityScore,
+				versionState,
+				hasDownloadLink,
+				isAutoDownloadCandidate,
+				isRecommended: false,
+				recommendationTier: 'low' as const,
+				recommendationReason: ''
+			};
+		})
+		.sort((a, b) => {
+			if (a.isAutoDownloadCandidate !== b.isAutoDownloadCandidate) {
+				return a.isAutoDownloadCandidate ? -1 : 1;
+			}
+
+			if (b.recommendationScore !== a.recommendationScore) {
+				return b.recommendationScore - a.recommendationScore;
+			}
+
+			const seederDiff = (normalizeMetric(b.seeders) ?? 0) - (normalizeMetric(a.seeders) ?? 0);
+			if (seederDiff !== 0) {
+				return seederDiff;
+			}
+
+			return toTimestamp(b.uploadDate) - toTimestamp(a.uploadDate);
+		});
+
+	const selectedReleaseId =
+		scoredReleases.find((release) => release.isAutoDownloadCandidate)?.id ?? null;
+
+	const rankedReleases = scoredReleases.map((release) => {
+		const isRecommended = release.id === selectedReleaseId;
+
+		return {
+			...release,
+			isRecommended,
+			recommendationTier: isRecommended ? ('high' as const) : ('low' as const),
+			recommendationReason: isRecommended
+				? buildRecommendationReason(release, gameHasOwnedVersion)
+				: ''
+		};
+	});
+
+	const selectedRelease =
+		selectedReleaseId === null
+			? null
+			: rankedReleases.find((release) => release.id === selectedReleaseId) ?? null;
+
+	return {
+		rankedReleases,
+		selectedRelease
+	};
+}

--- a/src/lib/server/releaseSelection.ts
+++ b/src/lib/server/releaseSelection.ts
@@ -106,6 +106,7 @@ function getVersionScore(
 ): number {
 	if (isAutoDownloadCandidate) return 40;
 	if (!hasCurrentVersion) return parsedVersion ? 12 : 8;
+	if (versionState === 'newer') return 40;
 	if (versionState === 'same') return 22;
 	if (versionState === 'unknown') return 12;
 	return 0;

--- a/src/lib/server/scheduler.ts
+++ b/src/lib/server/scheduler.ts
@@ -1,12 +1,16 @@
-import cron, { type ScheduledTask } from 'node-cron';
 import { settings, updateSettings } from './config.js';
 import { db, runMigrations } from './database.js';
 import { appSettings } from './schema.js';
 import { runScanCycle } from './manager.js';
 import { logger, logError } from './logger.js';
+import { APP_VERSION_LABEL } from '../version.js';
 
 type SchedulerState = {
-	cronJob: ScheduledTask | null;
+	intervalHandle: ReturnType<typeof setInterval> | null;
+	currentScan: Promise<void> | null;
+	initialized: boolean;
+	intervalMinutesOverride: number | null;
+	nextRunAt: string | null;
 };
 
 const globalScheduler = globalThis as typeof globalThis & {
@@ -14,17 +18,47 @@ const globalScheduler = globalThis as typeof globalThis & {
 };
 
 if (!globalScheduler.__repackarrSchedulerState) {
-	globalScheduler.__repackarrSchedulerState = { cronJob: null };
+	globalScheduler.__repackarrSchedulerState = {
+		intervalHandle: null,
+		currentScan: null,
+		initialized: false,
+		intervalMinutesOverride: null,
+		nextRunAt: null
+	};
 }
 
 const schedulerState = globalScheduler.__repackarrSchedulerState;
 
-function minutesToCron(minutes: number): string {
-	if (minutes < 60) return `*/${minutes} * * * *`;
-	const hours = Math.floor(minutes / 60);
-	const remainingMinutes = minutes % 60;
-	if (remainingMinutes === 0) return `0 */${hours} * * *`;
-	return `${remainingMinutes} */${hours} * * *`;
+function getIntervalMinutes(): number {
+	return schedulerState.intervalMinutesOverride ?? settings.CRON_INTERVAL_MINUTES;
+}
+
+function getIntervalMs(): number {
+	return getIntervalMinutes() * 60 * 1000;
+}
+
+function updateNextRunAt(intervalMs: number): void {
+	schedulerState.nextRunAt = new Date(Date.now() + intervalMs).toISOString();
+}
+
+async function runScheduledScan(trigger: 'startup' | 'interval'): Promise<void> {
+	if (schedulerState.currentScan) {
+		logger.warn(`[Scheduler] Skipping ${trigger} scan because another scan is already running.`);
+		return;
+	}
+
+	logger.info(`[Scheduler] Starting ${trigger} full scan...`);
+
+	const scanPromise = runScanCycle()
+		.catch((error) => logError(`[Scheduler] ${trigger} scan failed`, error))
+		.finally(() => {
+			if (schedulerState.currentScan === scanPromise) {
+				schedulerState.currentScan = null;
+			}
+		});
+
+	schedulerState.currentScan = scanPromise;
+	await scanPromise;
 }
 
 export function loadSettingsFromDb(): void {
@@ -55,32 +89,41 @@ export function loadSettingsFromDb(): void {
 }
 
 export function startScheduler(): void {
-	const cronExpression = minutesToCron(settings.CRON_INTERVAL_MINUTES);
+	const intervalMinutes = getIntervalMinutes();
+	const intervalMs = getIntervalMs();
 
-	if (schedulerState.cronJob) {
-		schedulerState.cronJob.stop();
+	if (schedulerState.intervalHandle) {
+		clearInterval(schedulerState.intervalHandle);
 	}
 
-	schedulerState.cronJob = cron.schedule(cronExpression, () => {
-		runScanCycle().catch((error) => logError('Scheduled scan failed', error));
-	});
+	updateNextRunAt(intervalMs);
+	schedulerState.intervalHandle = setInterval(() => {
+		updateNextRunAt(intervalMs);
+		void runScheduledScan('interval');
+	}, intervalMs);
 
 	logger.info(
-		`Scheduler started (interval: ${settings.CRON_INTERVAL_MINUTES} min, cron: ${cronExpression})`
+		`Scheduler started (interval: ${intervalMinutes} min, startup scan: enabled, next run at: ${schedulerState.nextRunAt})`
 	);
 }
 
 export function rescheduleJob(minutes: number): void {
-	settings.CRON_INTERVAL_MINUTES = minutes;
+	schedulerState.intervalMinutesOverride = minutes;
 	startScheduler();
 }
 
 export function initApp(): void {
-	logger.info(`Starting Repackarr v0.1.0`);
+	if (schedulerState.initialized) {
+		return;
+	}
+
+	logger.info(`Starting Repackarr ${APP_VERSION_LABEL}`);
 
 	runMigrations();
 
 	loadSettingsFromDb();
 
 	startScheduler();
+	schedulerState.initialized = true;
+	void runScheduledScan('startup');
 }

--- a/src/lib/server/schema.ts
+++ b/src/lib/server/schema.ts
@@ -19,6 +19,7 @@ export const games = sqliteTable('game', {
 	sourceUrl: text('source_url'),
 	rawName: text('raw_name'), // Store the original torrent name for version healing
 	infoHash: text('info_hash'), // Store the unique torrent hash for precise healing
+	autoDownloadEnabled: integer('auto_download_enabled', { mode: 'boolean' }), // null=use global, true=always, false=never
 	createdAt: text('created_at')
 		.notNull()
 		.$defaultFn(() => new Date().toISOString()),
@@ -85,6 +86,23 @@ export const ignoredReleases = sqliteTable('ignored_release', {
 	index('idx_ignored_release_game_id').on(table.gameId)
 ]);
 
+export const notifications = sqliteTable('notification', {
+	id: integer('id').primaryKey({ autoIncrement: true }),
+	type: text('type', {
+		enum: ['auto_download_success', 'auto_download_failed', 'auto_download_skipped']
+	}).notNull(),
+	gameId: integer('game_id').references(() => games.id, { onDelete: 'cascade' }),
+	gameTitle: text('game_title').notNull(),
+	message: text('message').notNull(),
+	isRead: integer('is_read', { mode: 'boolean' }).notNull().default(false),
+	createdAt: text('created_at')
+		.notNull()
+		.$defaultFn(() => new Date().toISOString())
+}, (table) => [
+	index('idx_notification_is_read').on(table.isRead),
+	index('idx_notification_created_at').on(table.createdAt)
+]);
+
 export type Game = typeof games.$inferSelect;
 export type NewGame = typeof games.$inferInsert;
 export type Release = typeof releases.$inferSelect;
@@ -92,3 +110,4 @@ export type NewRelease = typeof releases.$inferInsert;
 export type AppSetting = typeof appSettings.$inferSelect;
 export type ScanLog = typeof scanLogs.$inferSelect;
 export type IgnoredRelease = typeof ignoredReleases.$inferSelect;
+export type Notification = typeof notifications.$inferSelect;

--- a/src/lib/server/validators.ts
+++ b/src/lib/server/validators.ts
@@ -55,6 +55,12 @@ export function validateDownloadUrl(url: string | null | undefined): boolean {
 	return trimmed.startsWith('magnet:') || trimmed.startsWith('http://') || trimmed.startsWith('https://');
 }
 
+export function extractMagnetHash(url: string | null | undefined): string | null {
+	if (!url) return null;
+	const match = url.match(/btih:([a-fA-F0-9]{40})/i);
+	return match ? match[1].toLowerCase() : null;
+}
+
 /**
  * Retry options for async operations
  */

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,4 @@
+import packageJson from '../../package.json';
+
+export const APP_VERSION = packageJson.version;
+export const APP_VERSION_LABEL = `v${APP_VERSION}`;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -150,6 +150,7 @@
 				stopProgressTracking();
 				toastStore.error(result.error || 'Scan failed', 'Full Scan');
 			} else {
+				stopProgressTracking();
 				toastStore.success('Full scan complete', 'Full Scan');
 				await invalidateAll();
 			}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
 	import { browser } from '$app/environment';
 	import { invalidateAll } from '$app/navigation';
 	import ToastContainer from '$lib/components/ui/ToastContainer.svelte';
+	import NotificationPanel from '$lib/components/ui/NotificationPanel.svelte';
 	import { toastStore } from '$lib/stores/toast.js';
 
 	let { children } = $props();
@@ -281,6 +282,9 @@
 					{/if}
 					<span>Full Scan</span>
 				</button>
+
+				<!-- Notification Bell -->
+				<NotificationPanel />
 			</div>
 			
 			<!-- Progress Bar -->

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
 	import ToastContainer from '$lib/components/ui/ToastContainer.svelte';
 	import NotificationPanel from '$lib/components/ui/NotificationPanel.svelte';
 	import { toastStore } from '$lib/stores/toast.js';
+	import { APP_VERSION } from '$lib/version.js';
 
 	let { children } = $props();
 
@@ -13,7 +14,7 @@
 		{ href: '/library', label: 'Library', icon: 'library' },
 		{ href: '/settings', label: 'Settings', icon: 'settings' }
 	];
-	const appVersion = '0.1.1';
+	const appVersion = APP_VERSION;
 	const changelog = [
 		{
 			version: '0.1.1',
@@ -45,6 +46,7 @@
 		startedAt: null as string | null
 	});
 	let eventSource: EventSource | null = null;
+	let hasSeenActiveScan = false;
 
 	function getIcon(icon: string) {
 		const icons: Record<string, string> = {
@@ -55,31 +57,37 @@
 		return icons[icon] || icons.home;
 	}
 
-	function startProgressTracking() {
+	function stopProgressTracking() {
 		if (eventSource) {
 			eventSource.close();
+			eventSource = null;
 		}
-		
+
+		hasSeenActiveScan = false;
+	}
+
+	function startProgressTracking() {
+		stopProgressTracking();
 		eventSource = new EventSource('/api/scan/progress');
 		eventSource.onmessage = (event) => {
 			try {
 				const data = JSON.parse(event.data);
 				scanProgress = data;
-				
-				if (!data.isScanning && eventSource) {
-					eventSource.close();
-					eventSource = null;
+
+				if (data.isScanning) {
+					hasSeenActiveScan = true;
+				}
+
+				if (hasSeenActiveScan && !data.isScanning) {
+					stopProgressTracking();
 				}
 			} catch (error) {
 				console.error('Error parsing progress:', error);
 			}
 		};
-		
+
 		eventSource.onerror = () => {
-			if (eventSource) {
-				eventSource.close();
-				eventSource = null;
-			}
+			stopProgressTracking();
 		};
 	}
 
@@ -90,6 +98,7 @@
 			const resp = await fetch('/api/sync-library', { method: 'POST' });
 			const result = await resp.json();
 			if (result.success) {
+				stopProgressTracking();
 				const count = result.added || 0;
 				if (count > 0) {
 					toastStore.success(`Synced ${count} game${count !== 1 ? 's' : ''}`, 'Sync Library');
@@ -98,9 +107,11 @@
 				}
 				await invalidateAll();
 			} else {
+				stopProgressTracking();
 				toastStore.error(result.message || 'Sync failed', 'Sync Library');
 			}
 		} catch {
+			stopProgressTracking();
 			toastStore.error('Network error', 'Sync Library');
 		} finally {
 			scanning = false;
@@ -114,12 +125,15 @@
 			const resp = await fetch('/api/check-updates', { method: 'POST' });
 			const result = await resp.json();
 			if (result.success) {
-				toastStore.success('Update check complete', 'Check Updates');
+				stopProgressTracking();
+				toastStore.success(result.message || 'Update check complete', 'Check Updates');
 				await invalidateAll();
 			} else {
+				stopProgressTracking();
 				toastStore.error(result.error || 'Search failed', 'Check Updates');
 			}
 		} catch {
+			stopProgressTracking();
 			toastStore.error('Network error', 'Check Updates');
 		} finally {
 			scanning = false;
@@ -133,12 +147,14 @@
 			const resp = await fetch('/api/scan?type=full', { method: 'POST' });
 			const result = await resp.json();
 			if (!result.success) {
+				stopProgressTracking();
 				toastStore.error(result.error || 'Scan failed', 'Full Scan');
 			} else {
 				toastStore.success('Full scan complete', 'Full Scan');
 				await invalidateAll();
 			}
 		} catch {
+			stopProgressTracking();
 			toastStore.error('Network error', 'Full Scan');
 		} finally {
 			scanning = false;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,21 +19,21 @@
 		{
 			version: '0.1.2',
 			notes: [
-				'Auto-Download can now grab the best matching release for eligible games automatically',
-				'New notifications show when automatic downloads succeed, fail, or are skipped',
-				'You can control AutoDL globally or override it per game from the Library',
-				'Adding a game is clearer with "I Want This Game" and "I Already Have It" modes',
-				'Scans now start on launch and scheduled runs no longer overlap',
-				'Recommended releases now match the exact AutoDL choice'
+				'Auto-Download can now grab matching updates for you automatically',
+				'New notifications keep you posted when automatic downloads succeed, fail, or are skipped',
+				'You can control AutoDL for the whole library or set it per game',
+				'Adding a game is clearer with "I Want This Game" and "I Already Have It" choices',
+				'Scans now start automatically after launch and feel more reliable',
+				'Dashboard recommendations now line up better with what Auto-Download would pick'
 			]
 		},
 		{
 			version: '0.1.1',
 			notes: [
-				'Download and upload speed limits can now be set per torrent',
-				'Speed limits are now loaded from qBittorrent on page open',
-				'Upload speed is now shown in torrent status',
-				'Turtle mode toggle added to quickly throttle all speeds',
+				'You can now set download and upload limits per torrent',
+				'Current speed limits are loaded from qBittorrent when the page opens',
+				'Upload speed is now shown alongside download speed',
+				'Turtle mode makes it easy to slow everything down',
 				'Torrent control buttons redesigned for a cleaner look'
 			]
 		},

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -17,6 +17,17 @@
 	const appVersion = APP_VERSION;
 	const changelog = [
 		{
+			version: '0.1.2',
+			notes: [
+				'Auto-Download can now grab the best matching release for eligible games automatically',
+				'New notifications show when automatic downloads succeed, fail, or are skipped',
+				'You can control AutoDL globally or override it per game from the Library',
+				'Adding a game is clearer with "I Want This Game" and "I Already Have It" modes',
+				'Scans now start on launch and scheduled runs no longer overlap',
+				'Recommended releases now match the exact AutoDL choice'
+			]
+		},
+		{
 			version: '0.1.1',
 			notes: [
 				'Download and upload speed limits can now be set per torrent',

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,54 +1,9 @@
 import { db } from '$lib/server/database.js';
 import { games, releases, scanLogs } from '$lib/server/schema.js';
 import { and, eq, sql } from 'drizzle-orm';
-import { compareVersions, estimateVersionConfidence, toTitleCaseWords } from '$lib/server/utils.js';
+import { rankGameReleases } from '$lib/server/releaseSelection.js';
+import { toTitleCaseWords } from '$lib/server/utils.js';
 import type { PageServerLoad } from './$types.js';
-
-const EPOCH_DATE = '1970-01-01T00:00:00.000Z';
-
-function toTimestamp(value: string): number {
-	const ts = Date.parse(value);
-	return isNaN(ts) ? 0 : ts;
-}
-
-function getRecencyScore(uploadDate: string): number {
-	const ts = toTimestamp(uploadDate);
-	if (!ts) return 0;
-
-	const ageDays = (Date.now() - ts) / (1000 * 60 * 60 * 24);
-	return Math.max(0, Math.round(40 - ageDays * 0.9));
-}
-
-function normalizeMetric(value: number | null | undefined): number | null {
-	if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return null;
-	return Math.trunc(value);
-}
-
-function getSeederScore(seeders: number | null): number {
-	if (!seeders || seeders <= 0) return 0;
-	const clamped = Math.min(seeders, 500);
-	return Math.round((Math.log10(clamped + 1) / Math.log10(501)) * 24);
-}
-
-function getGrabScore(grabs: number | null): number {
-	if (!grabs || grabs <= 0) return 0;
-	const clamped = Math.min(grabs, 1000);
-	return Math.round((Math.log10(clamped + 1) / Math.log10(1001)) * 10);
-}
-
-function getVersionScore(
-	currentVersion: string | null,
-	parsedVersion: string | null
-): { score: number; state: 'newer' | 'same' | 'older' | 'unknown' } {
-	if (!parsedVersion) return { score: 8, state: 'unknown' };
-	if (!currentVersion) return { score: 26, state: 'unknown' };
-
-	const cmp = compareVersions(currentVersion, parsedVersion);
-	if (cmp === -1) return { score: 40, state: 'newer' };
-	if (cmp === 0) return { score: 22, state: 'same' };
-	if (cmp === 1) return { score: 0, state: 'older' };
-	return { score: 12, state: 'unknown' };
-}
 
 export const load: PageServerLoad = async () => {
 	const totalGames = db.select({ count: sql<number>`count(*)` }).from(games).get()?.count ?? 0;
@@ -78,44 +33,12 @@ export const load: PageServerLoad = async () => {
 
 	const allGames = db.select().from(games).all();
 	const gameMap = new Map(allGames.map((g) => [g.id, g]));
-	const latestVersionByGame = new Map<number, string>();
-
-	for (const rel of allReleases) {
-		if (!rel.parsedVersion) continue;
-
-		const relGame = gameMap.get(rel.gameId);
-		if (!relGame || relGame.status !== 'monitored') continue;
-
-		const currentLatest = latestVersionByGame.get(rel.gameId);
-		if (!currentLatest) {
-			latestVersionByGame.set(rel.gameId, rel.parsedVersion);
-			continue;
-		}
-
-		const cmp = compareVersions(currentLatest, rel.parsedVersion);
-		if (cmp === -1) {
-			latestVersionByGame.set(rel.gameId, rel.parsedVersion);
-		}
-	}
-
-	type ScoredRelease = (typeof allReleases)[0] & {
-		recommendationScore: number;
-		recommendationTier: 'high' | 'medium' | 'low';
-		confidenceScore: number;
-		freshnessScore: number;
-		popularityScore: number;
-		seederScore: number;
-		grabScore: number;
-		versionState: 'newer' | 'same' | 'older' | 'unknown';
-		recommendationCandidate: boolean;
-		recommendationReason: string;
-	};
 
 	const grouped: Record<
 		number,
 		{
 			game: (typeof allGames)[0];
-			releases: ScoredRelease[];
+			releases: (typeof allReleases)[0][];
 		}
 	> = {};
 
@@ -131,118 +54,13 @@ export const load: PageServerLoad = async () => {
 				releases: []
 			};
 		}
-		const confidenceRaw = estimateVersionConfidence(rel.rawTitle, rel.parsedVersion);
-		const confidenceScore = Math.round((confidenceRaw / 100) * 20);
-		const freshnessScore = getRecencyScore(rel.uploadDate);
-		const seeders = normalizeMetric(rel.seeders);
-		const leechers = normalizeMetric(rel.leechers);
-		const grabs = normalizeMetric(rel.grabs);
-		const seederScore = getSeederScore(seeders);
-		const grabScore = getGrabScore(grabs);
-		const popularityScore = seederScore + grabScore;
-		const hasOwnedVersion = Boolean(
-			game.currentVersion && game.currentVersionDate && game.currentVersionDate !== EPOCH_DATE
-		);
-		const effectiveCurrentVersion = hasOwnedVersion ? game.currentVersion : null;
-		const version = getVersionScore(effectiveCurrentVersion, rel.parsedVersion);
-		const latestVersion = latestVersionByGame.get(game.id) ?? null;
-		const isTopVersionCandidate =
-			!hasOwnedVersion &&
-			Boolean(rel.parsedVersion) &&
-			Boolean(latestVersion) &&
-			compareVersions(latestVersion!, rel.parsedVersion!) === 0;
-		let hasNewerVersionAvailable = false;
-		if (hasOwnedVersion && effectiveCurrentVersion && latestVersion) {
-			hasNewerVersionAvailable =
-				compareVersions(effectiveCurrentVersion, latestVersion) === -1;
-		}
-		const versionScore = hasOwnedVersion
-			? version.score
-			: isTopVersionCandidate
-				? 40
-				: rel.parsedVersion
-					? 12
-					: 8;
-		const recommendationScore = versionScore + confidenceScore + freshnessScore + popularityScore;
-		const shouldRecommend = hasOwnedVersion
-			? version.state === 'newer' || (!hasNewerVersionAvailable && version.state === 'same')
-			: isTopVersionCandidate;
-		const recommendationLabel = hasOwnedVersion
-			? version.state === 'newer'
-				? 'Newer Version'
-				: !hasNewerVersionAvailable && version.state === 'same'
-					? 'Recommended'
-					: null
-			: isTopVersionCandidate
-				? 'Recommended'
-				: null;
-		const recommendationReason = recommendationLabel
-			? [
-					recommendationLabel,
-					seeders !== null ? `${seeders} seeders` : null,
-					leechers !== null ? `${leechers} leechers` : null,
-					grabs !== null ? `${grabs} grabs` : null
-				]
-					.filter((part): part is string => Boolean(part))
-					.join(' • ')
-			: '';
-
-		grouped[game.id].releases.push({
-			...rel,
-			recommendationScore,
-			recommendationTier: shouldRecommend ? (version.state === 'newer' ? 'high' : 'medium') : 'low',
-			confidenceScore,
-			freshnessScore,
-			popularityScore,
-			seederScore,
-			grabScore,
-			versionState: version.state,
-			recommendationCandidate: shouldRecommend,
-			recommendationReason
-		});
+		grouped[game.id].releases.push(rel);
 	}
 
-	for (const group of Object.values(grouped)) {
-		const sortedReleases = group.releases
-			.sort((a, b) => {
-				if (b.recommendationScore !== a.recommendationScore) {
-					return b.recommendationScore - a.recommendationScore;
-				}
-				const seederDiff = (normalizeMetric(b.seeders) ?? 0) - (normalizeMetric(a.seeders) ?? 0);
-				if (seederDiff !== 0) {
-					return seederDiff;
-				}
-				return toTimestamp(b.uploadDate) - toTimestamp(a.uploadDate);
-			});
-
-		const recommendedVersions = new Set<string>();
-		let recommendedCount = 0;
-		const maxRecommendationsPerGame = 2;
-
-		group.releases = sortedReleases.map((rel) => {
-			if (!rel.recommendationCandidate) {
-				return rel;
-			}
-
-			const versionKey = rel.parsedVersion ?? `release-${rel.id}`;
-			if (
-				recommendedCount >= maxRecommendationsPerGame ||
-				recommendedVersions.has(versionKey)
-			) {
-				return { ...rel, recommendationTier: 'low' };
-			}
-
-			recommendedVersions.add(versionKey);
-			recommendedCount++;
-
-			return {
-				...rel,
-				recommendationTier: rel.recommendationScore >= 88 ? 'high' : 'medium'
-			};
-		});
-	}
-
-	const updates = Object.values(grouped);
+	const updates = Object.values(grouped).map((group) => ({
+		game: group.game,
+		releases: rankGameReleases(group.game, group.releases).rankedReleases
+	}));
 
 	// Recent logs
 	const logs = db

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -289,15 +289,20 @@
 											{#if release.parsedVersion}
 												• v{release.parsedVersion}
 											{/if}
-											{#if release.recommendationTier === 'high' || release.recommendationTier === 'medium'}
+											{#if release.isRecommended}
 												<span
 													class="ml-2 inline-flex items-center px-1.5 py-0.5 rounded border border-emerald-500/40 bg-emerald-500/15 text-[10px] font-semibold text-emerald-300"
-													title={`${release.recommendationReason || 'Scored recommendation'} • Score ${release.recommendationScore} • Version ${release.versionState}`}
+													title={`${release.recommendationReason || 'Recommended'} • Score ${release.recommendationScore} • Version ${release.versionState}`}
 												>
 													Recommended
 												</span>
 											{/if}
 										</p>
+										{#if release.isRecommended && release.recommendationReason}
+											<p class="mt-1 text-[11px] text-emerald-300/90">
+												AutoDL choice: {release.recommendationReason}
+											</p>
+										{/if}
 									</div>
 									<div class="flex gap-1.5 ml-3 shrink-0">
 									{#if actionFeedback[release.id]}

--- a/src/routes/api/check-updates/+server.ts
+++ b/src/routes/api/check-updates/+server.ts
@@ -20,7 +20,7 @@ export const POST: RequestHandler = async () => {
 		return json(
 			{
 				success: false,
-				error: error instanceof Error ? error.message : 'Internal server error'
+				error: 'Internal server error'
 			},
 			{ status: 500 }
 		);

--- a/src/routes/api/check-updates/+server.ts
+++ b/src/routes/api/check-updates/+server.ts
@@ -6,14 +6,12 @@ import { logger } from '$lib/server/logger.js';
 
 export const POST: RequestHandler = async () => {
 	try {
-		// Start the search updates in background
-		runSearchUpdates().then(() => {
-			progressManager.complete();
-		});
-		
+		const scanned = await runSearchUpdates(undefined, { throwOnError: true });
+
 		return json({
 			success: true,
-			message: 'Update search started'
+			message: 'Update check complete',
+			scanned
 		});
 	} catch (error) {
 		logger.error('Error checking updates:', error);
@@ -24,5 +22,7 @@ export const POST: RequestHandler = async () => {
 			},
 			{ status: 500 }
 		);
+	} finally {
+		progressManager.complete();
 	}
 };

--- a/src/routes/api/games/[id]/auto-download/+server.ts
+++ b/src/routes/api/games/[id]/auto-download/+server.ts
@@ -1,0 +1,29 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types.js';
+import { db } from '$lib/server/database.js';
+import { games } from '$lib/server/schema.js';
+import { eq } from 'drizzle-orm';
+import { validateId, errorResponse } from '$lib/server/validators.js';
+
+export const POST: RequestHandler = async ({ params, request }) => {
+	const id = validateId(params.id);
+	if (id === null) return json(errorResponse('Invalid game ID'), { status: 400 });
+
+	const game = db.select().from(games).where(eq(games.id, id)).get();
+	if (!game) return json(errorResponse('Game not found'), { status: 404 });
+
+	const body = await request.json().catch(() => null);
+
+	// enabled: true = always, false = never, null = use global
+	let autoDownloadEnabled: boolean | null = null;
+	if (body && body.enabled === true) autoDownloadEnabled = true;
+	else if (body && body.enabled === false) autoDownloadEnabled = false;
+	// else null = global
+
+	db.update(games)
+		.set({ autoDownloadEnabled })
+		.where(eq(games.id, id))
+		.run();
+
+	return json({ success: true, autoDownloadEnabled });
+};

--- a/src/routes/api/games/[id]/reset-scan/+server.ts
+++ b/src/routes/api/games/[id]/reset-scan/+server.ts
@@ -35,6 +35,6 @@ export const POST: RequestHandler = async ({ params }) => {
 		}));
 	} catch (error) {
 		logger.error(`Reset scan failed for game ${id}:`, error);
-		return json(errorResponse('Search failed: ' + String(error).slice(0, 80)), { status: 500 });
+		return json(errorResponse('Search failed'), { status: 500 });
 	}
 };

--- a/src/routes/api/notifications/+server.ts
+++ b/src/routes/api/notifications/+server.ts
@@ -1,0 +1,18 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types.js';
+import { db } from '$lib/server/database.js';
+import { notifications } from '$lib/server/schema.js';
+import { eq, desc } from 'drizzle-orm';
+
+export const GET: RequestHandler = async () => {
+	const all = db
+		.select()
+		.from(notifications)
+		.orderBy(desc(notifications.createdAt))
+		.limit(50)
+		.all();
+
+	const unreadCount = all.filter((n) => !n.isRead).length;
+
+	return json({ notifications: all, unreadCount });
+};

--- a/src/routes/api/notifications/+server.ts
+++ b/src/routes/api/notifications/+server.ts
@@ -2,7 +2,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types.js';
 import { db } from '$lib/server/database.js';
 import { notifications } from '$lib/server/schema.js';
-import { eq, desc } from 'drizzle-orm';
+import { desc } from 'drizzle-orm';
 
 export const GET: RequestHandler = async () => {
 	const all = db

--- a/src/routes/api/notifications/+server.ts
+++ b/src/routes/api/notifications/+server.ts
@@ -2,7 +2,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types.js';
 import { db } from '$lib/server/database.js';
 import { notifications } from '$lib/server/schema.js';
-import { desc } from 'drizzle-orm';
+import { desc, eq, sql } from 'drizzle-orm';
 
 export const GET: RequestHandler = async () => {
 	const all = db
@@ -12,7 +12,11 @@ export const GET: RequestHandler = async () => {
 		.limit(50)
 		.all();
 
-	const unreadCount = all.filter((n) => !n.isRead).length;
+	const unreadCount = db
+		.select({ count: sql<number>`count(*)` })
+		.from(notifications)
+		.where(eq(notifications.isRead, false))
+		.get()?.count ?? 0;
 
 	return json({ notifications: all, unreadCount });
 };

--- a/src/routes/api/notifications/read/+server.ts
+++ b/src/routes/api/notifications/read/+server.ts
@@ -1,0 +1,10 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types.js';
+import { db } from '$lib/server/database.js';
+import { notifications } from '$lib/server/schema.js';
+import { eq } from 'drizzle-orm';
+
+export const POST: RequestHandler = async () => {
+	db.update(notifications).set({ isRead: true }).where(eq(notifications.isRead, false)).run();
+	return json({ success: true });
+};

--- a/src/routes/api/qbit/control/+server.ts
+++ b/src/routes/api/qbit/control/+server.ts
@@ -8,8 +8,8 @@ export const POST: RequestHandler = async ({ request }) => {
 		const body = await request.json();
 		const { action, hash } = body;
 
-		if (!hash || typeof hash !== 'string') {
-			return json({ error: 'Missing hash' }, { status: 400 });
+		if (!hash || typeof hash !== 'string' || !/^[a-fA-F0-9]{40}$/.test(hash)) {
+			return json({ error: 'Invalid hash' }, { status: 400 });
 		}
 
 		let ok = false;

--- a/src/routes/api/releases/[id]/download/+server.ts
+++ b/src/routes/api/releases/[id]/download/+server.ts
@@ -87,11 +87,17 @@ export const POST: RequestHandler = async ({ params }) => {
 	// Only after successful qBit addition, update database in a transaction
 	// This ensures atomicity: either all DB updates succeed or none do
 	try {
+		const nextRawName = release.rawTitle;
+		const nextInfoHash = newHash ?? null;
+		const nextSourceUrl = release.infoUrl ?? null;
 		transaction(() => {
 			// Update game version
 			db.update(games)
 				.set({
 					currentVersionDate: release.uploadDate,
+					rawName: nextRawName,
+					infoHash: nextInfoHash,
+					sourceUrl: nextSourceUrl,
 					...(release.parsedVersion ? { currentVersion: release.parsedVersion } : {})
 				})
 				.where(eq(games.id, game.id))

--- a/src/routes/api/releases/[id]/download/+server.ts
+++ b/src/routes/api/releases/[id]/download/+server.ts
@@ -4,13 +4,14 @@ import { db, transaction } from '$lib/server/database.js';
 import { releases, games } from '$lib/server/schema.js';
 import { eq } from 'drizzle-orm';
 import { qbitService } from '$lib/server/qbit.js';
-import { validateId, validateDownloadUrl, successResponse, errorResponse } from '$lib/server/validators.js';
+import {
+	validateId,
+	validateDownloadUrl,
+	successResponse,
+	errorResponse,
+	extractMagnetHash
+} from '$lib/server/validators.js';
 import { logger } from '$lib/server/logger.js';
-
-function extractMagnetHash(url: string): string | null {
-	const match = url.match(/btih:([a-fA-F0-9]{40})/i);
-	return match ? match[1].toLowerCase() : null;
-}
 
 export const POST: RequestHandler = async ({ params }) => {
         // Validate ID parameter

--- a/src/routes/api/releases/force-add/+server.ts
+++ b/src/routes/api/releases/force-add/+server.ts
@@ -7,6 +7,19 @@ import { extractVersion } from '$lib/server/utils.js';
 import { validateDownloadUrl } from '$lib/server/validators.js';
 import { logger } from '$lib/server/logger.js';
 
+function normalizeOptionalUrl(value: unknown): { value: string | null; invalidType: boolean } {
+	if (value === undefined || value === null) {
+		return { value: null, invalidType: false };
+	}
+
+	if (typeof value !== 'string') {
+		return { value: null, invalidType: true };
+	}
+
+	const trimmed = value.trim();
+	return { value: trimmed === '' ? null : trimmed, invalidType: false };
+}
+
 export const POST: RequestHandler = async ({ request }) => {
 	try {
 		const data = await request.json();
@@ -16,11 +29,21 @@ export const POST: RequestHandler = async ({ request }) => {
 			return json({ success: false, error: 'Missing required fields' }, { status: 400 });
 		}
 
-		// Validate provided URLs if present
-		if (magnetUrl !== undefined && magnetUrl !== null && !validateDownloadUrl(magnetUrl)) {
+		const normalizedMagnetUrl = normalizeOptionalUrl(magnetUrl);
+		if (normalizedMagnetUrl.invalidType) {
 			return json({ success: false, error: 'Invalid magnet/download URL' }, { status: 400 });
 		}
-		if (infoUrl !== undefined && infoUrl !== null && !validateDownloadUrl(infoUrl)) {
+
+		const normalizedInfoUrl = normalizeOptionalUrl(infoUrl);
+		if (normalizedInfoUrl.invalidType) {
+			return json({ success: false, error: 'Invalid info URL' }, { status: 400 });
+		}
+
+		// Validate provided URLs if present
+		if (normalizedMagnetUrl.value !== null && !validateDownloadUrl(normalizedMagnetUrl.value)) {
+			return json({ success: false, error: 'Invalid magnet/download URL' }, { status: 400 });
+		}
+		if (normalizedInfoUrl.value !== null && !validateDownloadUrl(normalizedInfoUrl.value)) {
 			return json({ success: false, error: 'Invalid info URL' }, { status: 400 });
 		}
 
@@ -62,8 +85,8 @@ export const POST: RequestHandler = async ({ request }) => {
 				parsedVersion,
 				uploadDate: uploadDate.toISOString(),
 				indexer: indexer || 'Unknown',
-				magnetUrl: magnetUrl || null,
-				infoUrl: infoUrl || null,
+				magnetUrl: normalizedMagnetUrl.value,
+				infoUrl: normalizedInfoUrl.value,
 				size: size || null,
 				isIgnored: false
 			})

--- a/src/routes/api/releases/force-add/+server.ts
+++ b/src/routes/api/releases/force-add/+server.ts
@@ -4,6 +4,7 @@ import { db } from '$lib/server/database.js';
 import { games, releases } from '$lib/server/schema.js';
 import { eq, and } from 'drizzle-orm';
 import { extractVersion } from '$lib/server/utils.js';
+import { validateDownloadUrl } from '$lib/server/validators.js';
 import { logger } from '$lib/server/logger.js';
 
 export const POST: RequestHandler = async ({ request }) => {
@@ -13,6 +14,14 @@ export const POST: RequestHandler = async ({ request }) => {
 
 		if (!gameId || !title) {
 			return json({ success: false, error: 'Missing required fields' }, { status: 400 });
+		}
+
+		// Validate provided URLs if present
+		if (magnetUrl !== undefined && magnetUrl !== null && !validateDownloadUrl(magnetUrl)) {
+			return json({ success: false, error: 'Invalid magnet/download URL' }, { status: 400 });
+		}
+		if (infoUrl !== undefined && infoUrl !== null && !validateDownloadUrl(infoUrl)) {
+			return json({ success: false, error: 'Invalid info URL' }, { status: 400 });
 		}
 
 		// Check if game exists

--- a/src/routes/api/scan/+server.ts
+++ b/src/routes/api/scan/+server.ts
@@ -20,6 +20,6 @@ export const POST: RequestHandler = async ({ url }) => {
 		return json({ success: true });
 	} catch (error) {
 		logger.error(`Scan failed: ${error}`);
-		return json({ success: false, error: String(error) }, { status: 500 });
+		return json({ success: false, error: 'Internal server error' }, { status: 500 });
 	}
 };

--- a/src/routes/api/scan/+server.ts
+++ b/src/routes/api/scan/+server.ts
@@ -9,17 +9,21 @@ export const POST: RequestHandler = async ({ url }) => {
 
 	try {
 		if (type === 'sync') {
-			await runSyncLibrary();
-			await progressManager.complete();
+			const synced = await runSyncLibrary(undefined, { throwOnError: true });
+			return json({ success: true, added: synced });
 		} else if (type === 'updates') {
-			await runSearchUpdates();
-			await progressManager.complete();
+			const scanned = await runSearchUpdates(undefined, { throwOnError: true });
+			return json({ success: true, scanned });
 		} else {
 			await runScanCycle();
+			return json({ success: true });
 		}
-		return json({ success: true });
 	} catch (error) {
 		logger.error(`Scan failed: ${error}`);
 		return json({ success: false, error: 'Internal server error' }, { status: 500 });
+	} finally {
+		if (type !== 'full') {
+			progressManager.complete();
+		}
 	}
 };

--- a/src/routes/api/settings/auto-download/+server.ts
+++ b/src/routes/api/settings/auto-download/+server.ts
@@ -1,0 +1,34 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types.js';
+import { db } from '$lib/server/database.js';
+import { appSettings } from '$lib/server/schema.js';
+import { eq } from 'drizzle-orm';
+
+const KEY = 'autoDownload';
+
+export const GET: RequestHandler = async () => {
+	const setting = db.select().from(appSettings).where(eq(appSettings.key, KEY)).get();
+	const enabled = setting?.value === 'true';
+	return json({ enabled });
+};
+
+export const POST: RequestHandler = async ({ request }) => {
+	const body = await request.json().catch(() => null);
+	let enabled: boolean;
+
+	if (body && typeof body.enabled === 'boolean') {
+		enabled = body.enabled;
+	} else {
+		// Toggle if no value provided
+		const current = db.select().from(appSettings).where(eq(appSettings.key, KEY)).get();
+		enabled = current?.value !== 'true';
+	}
+
+	const value = enabled ? 'true' : 'false';
+	db.insert(appSettings)
+		.values({ key: KEY, value })
+		.onConflictDoUpdate({ target: appSettings.key, set: { value, updatedAt: new Date().toISOString() } })
+		.run();
+
+	return json({ enabled });
+};

--- a/src/routes/api/sync-library/+server.ts
+++ b/src/routes/api/sync-library/+server.ts
@@ -1,14 +1,17 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types.js';
-import { qbitService } from '$lib/server/qbit.js';
+import { runSyncLibrary } from '$lib/server/manager.js';
 import { logger } from '$lib/server/logger.js';
+import { progressManager } from '$lib/server/progress.js';
 
 export const POST: RequestHandler = async () => {
 	try {
-		const synced = await qbitService.syncGames();
+		const synced = await runSyncLibrary(undefined, { throwOnError: true });
 		return json({ success: true, added: synced });
 	} catch (error) {
 		logger.error('Sync error:', error);
 		return json({ success: false, message: 'Internal server error' }, { status: 500 });
+	} finally {
+		progressManager.complete();
 	}
 };

--- a/src/routes/api/sync-library/+server.ts
+++ b/src/routes/api/sync-library/+server.ts
@@ -9,6 +9,6 @@ export const POST: RequestHandler = async () => {
 		return json({ success: true, added: synced });
 	} catch (error) {
 		logger.error('Sync error:', error);
-		return json({ success: false, message: String(error).slice(0, 100) }, { status: 500 });
+		return json({ success: false, message: 'Internal server error' }, { status: 500 });
 	}
 };

--- a/src/routes/api/system/logs/+server.ts
+++ b/src/routes/api/system/logs/+server.ts
@@ -63,6 +63,6 @@ export const GET: RequestHandler = async ({ url }) => {
 
         } catch (error) {
                 logger.error('Log read API error:', error);
-                return json({ error: 'Failed to read logs', details: String(error) }, { status: 500 });
+                return json({ error: 'Failed to read logs' }, { status: 500 });
         }
 };

--- a/src/routes/api/test/igdb/+server.ts
+++ b/src/routes/api/test/igdb/+server.ts
@@ -26,6 +26,6 @@ export const POST: RequestHandler = async () => {
 		const error = await authResp.text();
 		return json({ success: false, message: `Authentication failed: ${error.slice(0, 50)}` });
 	} catch (error) {
-		return json({ success: false, message: `Error: ${String(error).slice(0, 100)}` }, { status: 500 });
+		return json({ success: false, message: 'IGDB test failed' }, { status: 500 });
 	}
 };

--- a/src/routes/health/+server.ts
+++ b/src/routes/health/+server.ts
@@ -1,6 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types.js';
+import { APP_VERSION } from '$lib/version.js';
 
 export const GET: RequestHandler = async () => {
-	return json({ status: 'ok', version: '2.0.0' });
+	return json({ status: 'ok', version: APP_VERSION });
 };

--- a/src/routes/library/+page.server.ts
+++ b/src/routes/library/+page.server.ts
@@ -9,6 +9,7 @@ import { getGameMetadata } from '$lib/server/igdb.js';
 import { searchForGame } from '$lib/server/prowlarr.js';
 import { logger } from '$lib/server/logger.js';
 import { qbitService } from '$lib/server/qbit.js';
+import { tryAutoDownloadForGame } from '$lib/server/autoDownload.js';
 
 const METADATA_BACKFILL_INTERVAL_MS = 30 * 60 * 1000;
 let metadataBackfillRunning = false;
@@ -152,6 +153,7 @@ export const actions: Actions = {
 			// If searchNow is FALSE, we want to "silently" track the game.
 			// We do this by setting the currentVersionDate to the latest found release date,
 			// and then deleting the found releases so they don't show up on dashboard.
+			// Auto-download does NOT fire in Track Only mode (user says "I already have this version").
 			if (!searchNow && searchResult.totalFound > 0) {
 				const allFound = db.select().from(releases).where(eq(releases.gameId, result.id)).all();
 				if (allFound.length > 0) {
@@ -188,11 +190,26 @@ export const actions: Actions = {
 				}
 			}
 
+			// Search Now mode: attempt auto-download for the best qualifying release
+			let autoDownloaded = false;
+			let autoDownloadVersion: string | undefined;
+			if (searchNow && searchResult.added > 0) {
+				try {
+					const adResult = await tryAutoDownloadForGame(result.id);
+					autoDownloaded = adResult.success;
+					autoDownloadVersion = adResult.version;
+				} catch (err) {
+					logger.warn(`Auto-download failed for new game '${result.title}': ${err}`);
+				}
+			}
+
 			return { 
 				success: true, 
 				gameId: result.id,
 				foundReleases: searchNow ? searchResult.added : 0,
-				redirectToDashboard: searchNow
+				redirectToDashboard: searchNow,
+				autoDownloaded,
+				autoDownloadVersion
 			};
 		}
 

--- a/src/routes/library/+page.svelte
+++ b/src/routes/library/+page.svelte
@@ -769,13 +769,14 @@
 						<th class="px-4 py-3 text-xs font-medium text-slate-400 uppercase">Status</th>
 						<th class="px-4 py-3 text-xs font-medium text-slate-400 uppercase">Updates</th>
 						<th class="px-4 py-3 text-xs font-medium text-slate-400 uppercase">Links</th>
+						<th class="px-4 py-3 text-xs font-medium text-slate-400 uppercase">AutoDL</th>
 						<th class="px-4 py-3 text-xs font-medium text-slate-400 uppercase">Actions</th>
 					</tr>
 				</thead>
 				<tbody class="divide-y divide-slate-700/50">
 					{#if filteredGames.length === 0}
 						<tr>
-							<td colspan="6" class="px-4 py-16 text-center">
+							<td colspan="7" class="px-4 py-16 text-center">
 								<div class="flex flex-col items-center gap-4 text-slate-400">
 									<svg class="w-16 h-16 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -1065,29 +1066,28 @@
 									{/if}
 								</div>
 							</td>
+							<!-- AutoDL column -->
+							<td class="px-4 py-3">
+								<div class="flex rounded-lg overflow-hidden border border-slate-600/50 text-[10px] font-medium">
+									<button
+										onclick={() => setGameAutoDownload(game.id, null)}
+										class="px-2 py-1.5 transition-colors {(perGameAutoDownload[game.id] ?? null) === null ? 'bg-slate-500 text-white' : 'bg-slate-800 text-slate-500 hover:text-slate-300'}"
+										title="Follow the global AutoDL setting (top toolbar)"
+									>Global</button>
+									<button
+										onclick={() => setGameAutoDownload(game.id, true)}
+										class="px-2 py-1.5 border-x border-slate-600/50 transition-colors {perGameAutoDownload[game.id] === true ? 'bg-emerald-600 text-white' : 'bg-slate-800 text-slate-500 hover:text-emerald-400'}"
+										title="Always auto-download this game, regardless of global setting"
+									>Always</button>
+									<button
+										onclick={() => setGameAutoDownload(game.id, false)}
+										class="px-2 py-1.5 transition-colors {perGameAutoDownload[game.id] === false ? 'bg-red-700 text-white' : 'bg-slate-800 text-slate-500 hover:text-red-400'}"
+										title="Never auto-download this game, regardless of global setting"
+									>Never</button>
+								</div>
+							</td>
 							<td class="px-4 py-3">
 								<div class="flex flex-wrap gap-1.5">
-									<!-- Per-game Auto-Download toggle -->
-									<div class="flex items-center gap-1 shrink-0">
-										<span class="text-[10px] font-semibold text-slate-400 uppercase tracking-wide select-none">AutoDL:</span>
-										<div class="flex rounded-lg overflow-hidden border border-slate-600/50 text-[10px] font-medium">
-											<button
-												onclick={() => setGameAutoDownload(game.id, null)}
-												class="px-2 py-1.5 transition-colors {(perGameAutoDownload[game.id] ?? null) === null ? 'bg-slate-500 text-white' : 'bg-slate-800 text-slate-500 hover:text-slate-300'}"
-												title="Follow the global AutoDL setting (top toolbar)"
-											>Global</button>
-											<button
-												onclick={() => setGameAutoDownload(game.id, true)}
-												class="px-2 py-1.5 border-x border-slate-600/50 transition-colors {perGameAutoDownload[game.id] === true ? 'bg-emerald-600 text-white' : 'bg-slate-800 text-slate-500 hover:text-emerald-400'}"
-												title="Always auto-download this game, regardless of global setting"
-											>Always</button>
-											<button
-												onclick={() => setGameAutoDownload(game.id, false)}
-												class="px-2 py-1.5 transition-colors {perGameAutoDownload[game.id] === false ? 'bg-red-700 text-white' : 'bg-slate-800 text-slate-500 hover:text-red-400'}"
-												title="Never auto-download this game, regardless of global setting"
-											>Never</button>
-										</div>
-									</div>
 									<button
 										onclick={() => (editGameId = game.id)}
 										class="group px-2.5 py-1.5 bg-gradient-to-r from-slate-600 to-slate-700 hover:from-slate-500 hover:to-slate-600 text-white text-xs font-medium rounded-lg transition-all shadow-md hover:shadow-slate-500/30 flex items-center gap-1.5"

--- a/src/routes/library/+page.svelte
+++ b/src/routes/library/+page.svelte
@@ -84,6 +84,45 @@
 	let altSpeedMode = $state<0 | 1 | null>(null);
 	let altSpeedToggling = $state(false);
 
+	// Global auto-download toggle
+	let autoDownloadEnabled = $state<boolean>(false);
+	let autoDownloadToggling = $state(false);
+	// Per-game auto-download override: null = use global, true = always, false = never
+	let perGameAutoDownload = $state<Record<number, boolean | null>>({});
+
+	async function fetchAutoDownloadSetting() {
+		try {
+			const resp = await fetch('/api/settings/auto-download');
+			if (resp.ok) {
+				const data = await resp.json();
+				autoDownloadEnabled = data.enabled ?? false;
+			}
+		} catch { /* ignore */ }
+	}
+
+	async function toggleAutoDownload() {
+		autoDownloadToggling = true;
+		try {
+			const resp = await fetch('/api/settings/auto-download', { method: 'POST' });
+			if (resp.ok) {
+				const data = await resp.json();
+				autoDownloadEnabled = data.enabled ?? autoDownloadEnabled;
+			}
+		} catch { /* ignore */ }
+		autoDownloadToggling = false;
+	}
+
+	async function setGameAutoDownload(gameId: number, value: boolean | null) {
+		perGameAutoDownload = { ...perGameAutoDownload, [gameId]: value };
+		try {
+			await fetch(`/api/games/${gameId}/auto-download`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ enabled: value })
+			});
+		} catch { /* ignore */ }
+	}
+
 	async function fetchSpeedMode() {
 		try {
 			const resp = await fetch('/api/qbit/speed-mode');
@@ -165,6 +204,13 @@
 	$effect(() => {
 		fetchQbitStatus();
 		fetchSpeedMode();
+		fetchAutoDownloadSetting();
+		// Initialize per-game auto-download state from loaded data
+		const initial: Record<number, boolean | null> = {};
+		for (const game of data.games) {
+			initial[game.id] = game.autoDownloadEnabled ?? null;
+		}
+		perGameAutoDownload = initial;
 		const statusInterval = setInterval(fetchQbitStatus, 5000);
 		const speedInterval = setInterval(fetchSpeedMode, 10000);
 		return () => {
@@ -180,6 +226,7 @@
 		gameTitle = '';
 		searchQuery = '';
 		suggestions = [];
+		mode = 'download_now';
 	}
 
 	function closeSkippedModal() {
@@ -266,11 +313,20 @@
 				const foundCount = result.data?.foundReleases || 0;
 				const redirectToDashboard = result.data?.redirectToDashboard;
 				const message = result.data?.message;
+				const autoDownloaded = result.data?.autoDownloaded;
+				const autoDownloadVersion = result.data?.autoDownloadVersion;
 				
 				if (redirectToDashboard) {
-					const successMsg = foundCount > 0 
-						? `Game added! Found ${foundCount} releases. You can see them on the Dashboard.`
-						: 'Game added! Searching for releases in the background...';
+					let successMsg: string;
+					if (autoDownloaded) {
+						successMsg = autoDownloadVersion
+							? `Game added! v${autoDownloadVersion} is being downloaded automatically.`
+							: 'Game added! Best release is being downloaded automatically.';
+					} else if (foundCount > 0) {
+						successMsg = `Game added! Found ${foundCount} releases. You can see them on the Dashboard.`;
+					} else {
+						successMsg = 'Game added! Searching for releases in the background...';
+					}
 					
 					toastStore.success(successMsg, 'Add Game');
 					setTimeout(() => goto('/'), 1500);
@@ -648,6 +704,32 @@
 				{altSpeedMode === 1 ? 'Throttled' : 'Normal'}
 			</button>
 		{/if}
+
+		<!-- Global Auto-Download Toggle -->
+		<button
+			onclick={toggleAutoDownload}
+			disabled={autoDownloadToggling}
+			title={autoDownloadEnabled
+				? 'Auto-Download ON — Best high-tier releases are downloaded automatically. Click to disable.'
+				: 'Auto-Download OFF — Releases are shown on dashboard for manual selection. Click to enable.'}
+			class="px-3 py-2 text-sm font-medium rounded-lg border transition-all flex items-center gap-2 whitespace-nowrap disabled:opacity-60 disabled:cursor-not-allowed
+				{autoDownloadEnabled
+					? 'bg-emerald-500/20 border-emerald-500/40 text-emerald-400 hover:bg-emerald-500/30'
+					: 'bg-slate-800 border-slate-600 text-slate-400 hover:bg-slate-700 hover:text-slate-200'}"
+		>
+			{#if autoDownloadToggling}
+				<svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+			{:else}
+				<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					{#if autoDownloadEnabled}
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+					{:else}
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+					{/if}
+				</svg>
+			{/if}
+			Auto-DL {autoDownloadEnabled ? 'ON' : 'OFF'}
+		</button>
 	</div>
 
 	<!-- Stats -->
@@ -979,7 +1061,25 @@
 								</div>
 							</td>
 							<td class="px-4 py-3">
-								<div class="flex gap-1.5">
+								<div class="flex flex-wrap gap-1.5">
+									<!-- Per-game Auto-Download toggle -->
+									<div class="flex rounded-lg overflow-hidden border border-slate-600/50 text-[10px] font-medium shrink-0" title="Auto-Download override for this game">
+										<button
+											onclick={() => setGameAutoDownload(game.id, null)}
+											class="px-2 py-1.5 transition-colors {(perGameAutoDownload[game.id] ?? null) === null ? 'bg-slate-500 text-white' : 'bg-slate-800 text-slate-500 hover:text-slate-300'}"
+											title="Use global auto-download setting"
+										>Global</button>
+										<button
+											onclick={() => setGameAutoDownload(game.id, true)}
+											class="px-2 py-1.5 border-x border-slate-600/50 transition-colors {perGameAutoDownload[game.id] === true ? 'bg-emerald-600 text-white' : 'bg-slate-800 text-slate-500 hover:text-emerald-400'}"
+											title="Always auto-download for this game"
+										>Always</button>
+										<button
+											onclick={() => setGameAutoDownload(game.id, false)}
+											class="px-2 py-1.5 transition-colors {perGameAutoDownload[game.id] === false ? 'bg-red-700 text-white' : 'bg-slate-800 text-slate-500 hover:text-red-400'}"
+											title="Never auto-download for this game"
+										>Never</button>
+									</div>
 									<button
 										onclick={() => (editGameId = game.id)}
 										class="group px-2.5 py-1.5 bg-gradient-to-r from-slate-600 to-slate-700 hover:from-slate-500 hover:to-slate-600 text-white text-xs font-medium rounded-lg transition-all shadow-md hover:shadow-slate-500/30 flex items-center gap-1.5"
@@ -1192,25 +1292,65 @@
 					<p class="text-xs text-slate-500 mt-1.5">Comma-separated keywords to skip for this game only</p>
 				</div>
 
-				<!-- Options -->
-				<div class="space-y-3">
-					<label class="flex items-center gap-3 p-4 bg-slate-900/50 border border-slate-700/50 rounded-xl cursor-pointer hover:bg-slate-800/50 transition-all group">
-						<div class="relative flex items-center">
-							<input 
-								type="checkbox" 
-								name="search_now" 
-								checked={true}
-								class="peer h-5 w-5 cursor-pointer appearance-none rounded-md border border-slate-600 transition-all checked:border-purple-500 checked:bg-purple-500"
-							/>
-							<svg class="pointer-events-none absolute h-5 w-5 stroke-white opacity-0 peer-checked:opacity-100" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
-								<path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
-							</svg>
-						</div>
-						<div class="flex-1">
-							<div class="text-sm font-medium text-white">Find existing releases</div>
-							<div class="text-[10px] text-slate-500">Add currently available releases to your dashboard. Leave unchecked to only track future updates.</div>
-						</div>
-					</label>
+				<!-- Mode Selection Cards -->
+				<div>
+					<p class="block text-sm font-medium text-slate-300 mb-3">What do you want to do?</p>
+					<!-- Hidden input to carry the actual value -->
+					<input type="hidden" name="search_now" value={mode === 'download_now' ? 'on' : 'off'} />
+					<div class="grid grid-cols-2 gap-3">
+						<!-- Card: I Want This Game (Search Now) -->
+						<button
+							type="button"
+							onclick={() => (mode = 'download_now')}
+							class="relative flex flex-col gap-2 p-4 rounded-xl border-2 text-left transition-all
+								{mode === 'download_now'
+									? 'border-purple-500 bg-purple-500/10'
+									: 'border-slate-700 bg-slate-900/50 hover:border-slate-500'}"
+						>
+							{#if mode === 'download_now'}
+								<div class="absolute top-2 right-2 w-4 h-4 rounded-full bg-purple-500 flex items-center justify-center">
+									<svg class="w-2.5 h-2.5 text-white" fill="currentColor" viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>
+								</div>
+							{/if}
+							<div class="flex items-center gap-2">
+								<svg class="w-5 h-5 {mode === 'download_now' ? 'text-purple-400' : 'text-slate-400'}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+								</svg>
+								<span class="text-sm font-semibold {mode === 'download_now' ? 'text-white' : 'text-slate-300'}">I Want This Game</span>
+							</div>
+							<p class="text-[10px] text-slate-400 leading-relaxed">Searches for available releases.</p>
+							{#if autoDownloadEnabled}
+								<p class="text-[10px] text-emerald-400 font-medium">⚡ Auto-DL ON — best match will download automatically.</p>
+							{:else}
+								<p class="text-[10px] text-slate-500">Releases will be shown on dashboard for manual selection.</p>
+							{/if}
+						</button>
+
+						<!-- Card: I Already Have It (Track Only) -->
+						<button
+							type="button"
+							onclick={() => (mode = 'track_only')}
+							class="relative flex flex-col gap-2 p-4 rounded-xl border-2 text-left transition-all
+								{mode === 'track_only'
+									? 'border-blue-500 bg-blue-500/10'
+									: 'border-slate-700 bg-slate-900/50 hover:border-slate-500'}"
+						>
+							{#if mode === 'track_only'}
+								<div class="absolute top-2 right-2 w-4 h-4 rounded-full bg-blue-500 flex items-center justify-center">
+									<svg class="w-2.5 h-2.5 text-white" fill="currentColor" viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>
+								</div>
+							{/if}
+							<div class="flex items-center gap-2">
+								<svg class="w-5 h-5 {mode === 'track_only' ? 'text-blue-400' : 'text-slate-400'}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+								</svg>
+								<span class="text-sm font-semibold {mode === 'track_only' ? 'text-white' : 'text-slate-300'}">I Already Have It</span>
+							</div>
+							<p class="text-[10px] text-slate-400 leading-relaxed">Sets current version as baseline. Monitors for future updates only.</p>
+							<p class="text-[10px] text-slate-500">Use if you downloaded this game outside of Repackarr.</p>
+						</button>
+					</div>
 				</div>
 
 				<!-- Actions -->
@@ -1229,16 +1369,28 @@
 					<button
 						type="submit"
 						disabled={addingGame}
-						class="flex-1 px-4 py-3 bg-gradient-to-r from-purple-600 to-purple-800 hover:from-purple-700 hover:to-purple-900 disabled:from-purple-900 disabled:to-purple-950 disabled:cursor-not-allowed text-white font-semibold rounded-xl transition-all shadow-lg hover:shadow-purple-600/25 flex items-center justify-center gap-2 min-h-[44px]"
+						class="flex-1 px-4 py-3 bg-gradient-to-r
+							{mode === 'download_now'
+								? 'from-purple-600 to-purple-800 hover:from-purple-700 hover:to-purple-900 disabled:from-purple-900 disabled:to-purple-950'
+								: 'from-blue-600 to-blue-800 hover:from-blue-700 hover:to-blue-900 disabled:from-blue-900 disabled:to-blue-950'}
+							disabled:cursor-not-allowed text-white font-semibold rounded-xl transition-all shadow-lg flex items-center justify-center gap-2 min-h-[44px]"
 					>
 						{#if addingGame}
 							<svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
 								<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
 								<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
 							</svg>
-							<span>Adding Game...</span>
+							<span>{mode === 'download_now' ? 'Searching releases...' : 'Adding game...'}</span>
+						{:else if mode === 'download_now'}
+							<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+							</svg>
+							{autoDownloadEnabled ? 'Search & Auto-Download' : 'Search for Releases'}
 						{:else}
-							Add Game
+							<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0zM2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+							</svg>
+							Add & Track Only
 						{/if}
 					</button>
 				</div>

--- a/src/routes/library/+page.svelte
+++ b/src/routes/library/+page.svelte
@@ -230,8 +230,15 @@
 		addingGame = false;
 		gameTitle = '';
 		searchQuery = '';
+		platformFilter = 'Windows';
 		suggestions = [];
+		showSuggestions = false;
 		mode = 'download_now';
+	}
+
+	function openAddModal() {
+		closeAddModal();
+		showAddModal = true;
 	}
 
 	function closeSkippedModal() {
@@ -274,9 +281,7 @@
 			// Esc to close modals
 			if (e.key === 'Escape') {
 				if (showAddModal) {
-					showAddModal = false;
-					gameTitle = '';
-					searchQuery = '';
+					closeAddModal();
 				}
 				if (editGameId) {
 					editGameId = null;
@@ -334,18 +339,14 @@
 					}
 					
 					toastStore.success(successMsg, 'Add Game');
+					closeAddModal();
 					setTimeout(() => goto('/'), 1500);
 				} else {
 					toastStore.info(message || 'Game added to monitored list.', 'Add Game');
-					showAddModal = false;
+					closeAddModal();
 					await invalidateAll();
 				}
 				
-				// Clear form
-				addingGame = false;
-				gameTitle = '';
-				searchQuery = '';
-				platformFilter = 'Windows';
 			} else if (result.type === 'failure') {
 				toastStore.error(result.data?.error || 'Failed to add game');
 				addingGame = false; // Re-enable button on error
@@ -684,7 +685,7 @@
 
 		<div class="flex items-center gap-2 shrink-0">
 		<button
-			onclick={() => (showAddModal = true)}
+			onclick={openAddModal}
 			class="px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-2 whitespace-nowrap"
 		>
 			<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1369,11 +1370,7 @@
 				<div class="flex gap-3 pt-2">
 					<button
 						type="button"
-						onclick={() => {
-							showAddModal = false;
-							gameTitle = '';
-							searchQuery = '';
-						}}
+						onclick={closeAddModal}
 						class="flex-1 px-4 py-3 bg-slate-700 hover:bg-slate-600 text-white font-medium rounded-xl transition-colors"
 					>
 						Cancel

--- a/src/routes/library/+page.svelte
+++ b/src/routes/library/+page.svelte
@@ -654,7 +654,8 @@
 	<div class="flex items-center gap-4">
 		<h2 class="text-2xl font-bold text-white shrink-0">Game Library</h2>
 		
-		<div class="flex items-center gap-3 flex-1 max-w-2xl">
+		<div class="flex-1 flex justify-center">
+		<div class="flex items-center gap-3 w-full max-w-2xl">
 			<!-- Search Bar -->
 			<div class="relative flex-1">
 				<input
@@ -679,8 +680,9 @@
 				<option value="updates">Has Updates</option>
 			</select>
 		</div>
+		</div>
 
-		<div class="flex items-center gap-2 ml-auto shrink-0">
+		<div class="flex items-center gap-2 shrink-0">
 		<button
 			onclick={() => (showAddModal = true)}
 			class="px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-2 whitespace-nowrap"

--- a/src/routes/library/+page.svelte
+++ b/src/routes/library/+page.svelte
@@ -6,7 +6,7 @@
 	import { goto, invalidateAll } from '$app/navigation';
 
 	let { data }: { data: PageData } = $props();
-	
+
 	// Modal states
 	let confirmModal = $state<{
 		show: boolean;
@@ -31,7 +31,7 @@
 	// Delete modal torrent options
 	let deleteModalDeleteFromQbit = $state(false);
 	let deleteModalDeleteFiles = $state(false);
-	
+
 	// Add game form state
 	let gameTitle = $state('');
 	let searchQuery = $state('');
@@ -43,7 +43,7 @@
 	let abortController: AbortController | null = null;
 	const localCache = new Map<string, Array<{ name: string; display: string }>>();
 	let isSearching = $state(false);
-	
+
 	// Edit game autocomplete state
 	let editSuggestions = $state<Array<{ name: string; display: string }>>([]);
 	let showEditSuggestions = $state(false);
@@ -223,7 +223,7 @@
 			clearInterval(speedInterval);
 		};
 	});
-	
+
 	// Helper functions for modal close
 	function closeAddModal() {
 		showAddModal = false;
@@ -245,24 +245,24 @@
 		showSkippedFor = null;
 		skippedReleases = [];
 	}
-	
+
 	// Search & Filter state
 	let librarySearchQuery = $state('');
 	let filterStatus = $state<'all' | 'monitored' | 'unmonitored' | 'updates'>('all');
-	
+
 	// Filtered games
 	let filteredGames = $derived.by(() => {
 		let games = data.games;
-		
+
 		// Apply search filter
 		if (librarySearchQuery.trim()) {
 			const query = librarySearchQuery.toLowerCase();
-			games = games.filter(g => 
+			games = games.filter(g =>
 				g.title.toLowerCase().includes(query) ||
 				g.searchQuery.toLowerCase().includes(query)
 			);
 		}
-		
+
 		// Apply status filter
 		if (filterStatus === 'monitored') {
 			games = games.filter(g => g.status === 'monitored');
@@ -271,10 +271,10 @@
 		} else if (filterStatus === 'updates') {
 			games = games.filter(g => g.updateCount > 0);
 		}
-		
+
 		return games;
 	});
-	
+
 	// Keyboard shortcuts
 	$effect(() => {
 		function handleKeydown(e: KeyboardEvent) {
@@ -292,7 +292,7 @@
 				}
 			}
 		}
-		
+
 		window.addEventListener('keydown', handleKeydown);
 		return () => window.removeEventListener('keydown', handleKeydown);
 	});
@@ -305,12 +305,12 @@
 	async function handleAddGame(e: Event) {
 		e.preventDefault();
 		if (addingGame) return; // Prevent double submission
-		
+
 		addingGame = true;
 
 		const formData = new FormData(e.target as HTMLFormElement);
 		const searchNow = formData.get('search_now') === 'on';
-		
+
 		try {
 			const resp = await fetch('?/addGame', {
 				method: 'POST',
@@ -318,14 +318,14 @@
 			});
 
 			const result = await resp.json();
-			
+
 			if (result.type === 'success') {
 				const foundCount = result.data?.foundReleases || 0;
 				const redirectToDashboard = result.data?.redirectToDashboard;
 				const message = result.data?.message;
 				const autoDownloaded = result.data?.autoDownloaded;
 				const autoDownloadVersion = result.data?.autoDownloadVersion;
-				
+
 				if (redirectToDashboard) {
 					let successMsg: string;
 					if (autoDownloaded) {
@@ -337,7 +337,7 @@
 					} else {
 						successMsg = 'Game added! Searching for releases in the background...';
 					}
-					
+
 					toastStore.success(successMsg, 'Add Game');
 					closeAddModal();
 					setTimeout(() => goto('/'), 1500);
@@ -346,7 +346,7 @@
 					closeAddModal();
 					await invalidateAll();
 				}
-				
+
 			} else if (result.type === 'failure') {
 				toastStore.error(result.data?.error || 'Failed to add game');
 				addingGame = false; // Re-enable button on error
@@ -397,12 +397,12 @@
 		try {
 			const formData = new FormData();
 			formData.append('id', gameId.toString());
-			
+
 			const resp = await fetch('?/toggleMonitor', {
 				method: 'POST',
 				body: formData
 			});
-			
+
 			const result = await resp.json();
 			if (result.type === 'success') {
 				await invalidateAll();
@@ -416,13 +416,13 @@
 		const input = e.target as HTMLInputElement;
 		gameTitle = input.value;
 		const query = gameTitle.toLowerCase();
-		
+
 		if (gameTitle) {
 			searchQuery = gameTitle.toLowerCase();
 		}
 
 		if (autocompleteTimeout) clearTimeout(autocompleteTimeout);
-		
+
 		if (gameTitle.length < 2) {
 			suggestions = [];
 			showSuggestions = false;
@@ -463,7 +463,7 @@
 				});
 				const data = await resp.json();
 				const newSuggestions = data.suggestions || [];
-				
+
 				suggestions = newSuggestions;
 				if (newSuggestions.length > 0) {
 					localCache.set(cacheKey, newSuggestions);
@@ -488,9 +488,9 @@
 		const input = e.target as HTMLInputElement;
 		const title = input.value;
 		const query = title.toLowerCase();
-		
+
 		if (editAutocompleteTimeout) clearTimeout(editAutocompleteTimeout);
-		
+
 		if (title.length < 2) {
 			editSuggestions = [];
 			showEditSuggestions = false;
@@ -527,7 +527,7 @@
 				});
 				const data = await resp.json();
 				const newSuggestions = data.suggestions || [];
-				
+
 				editSuggestions = newSuggestions;
 				if (newSuggestions.length > 0) {
 					editLocalCache.set(query, newSuggestions);
@@ -585,10 +585,10 @@
 
 	async function forceAddRelease(skip: SkipInfo) {
 		if (!showSkippedFor) return;
-		
+
 		// Show immediate feedback
 		toastStore.info('Adding release...', 'Restore Release');
-		
+
 		try {
 			const resp = await fetch('/api/releases/force-add', {
 				method: 'POST',
@@ -603,7 +603,7 @@
 					date: skip.date
 				})
 			});
-			
+
 			const result = await resp.json();
 			if (result.success) {
 				// Show success feedback
@@ -622,17 +622,17 @@
 
 	async function handleEditGame(e: Event) {
 		e.preventDefault();
-		
+
 		const formData = new FormData(e.target as HTMLFormElement);
-		
+
 		try {
 			const resp = await fetch('?/updateGame', {
 				method: 'POST',
 				body: formData
 			});
-			
+
 			const result = await resp.json();
-			
+
 			if (result.type === 'success') {
 				toastStore.success('Game updated successfully!', 'Update Game');
 				editGameId = null;
@@ -654,45 +654,45 @@
 
 	<div class="flex items-center gap-4">
 		<h2 class="text-2xl font-bold text-white shrink-0">Game Library</h2>
-		
+
 		<div class="flex-1 flex justify-center">
-		<div class="flex items-center gap-3 w-full max-w-2xl">
-			<!-- Search Bar -->
-			<div class="relative flex-1">
-				<input
-					type="text"
-					bind:value={librarySearchQuery}
-					placeholder="Search games..."
-					class="w-full pl-10 pr-4 py-2 bg-slate-800 border border-slate-600 rounded-lg text-white text-sm placeholder-slate-400 focus:outline-none focus:border-purple-500 transition-colors"
-				/>
-				<svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-				</svg>
+			<div class="flex items-center gap-3 w-full max-w-2xl">
+				<!-- Search Bar -->
+				<div class="relative flex-1">
+					<input
+						type="text"
+						bind:value={librarySearchQuery}
+						placeholder="Search games..."
+						class="w-full pl-10 pr-4 py-2 bg-slate-800 border border-slate-600 rounded-lg text-white text-sm placeholder-slate-400 focus:outline-none focus:border-purple-500 transition-colors"
+					/>
+					<svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+					</svg>
+				</div>
+
+				<!-- Filter Dropdown -->
+				<select
+					bind:value={filterStatus}
+					class="px-3 py-2 bg-slate-800 border border-slate-600 rounded-lg text-white text-sm focus:outline-none focus:border-purple-500 transition-colors cursor-pointer"
+				>
+					<option value="all">All Games</option>
+					<option value="monitored">Monitored</option>
+					<option value="unmonitored">Unmonitored</option>
+					<option value="updates">Has Updates</option>
+				</select>
 			</div>
-			
-			<!-- Filter Dropdown -->
-			<select
-				bind:value={filterStatus}
-				class="px-3 py-2 bg-slate-800 border border-slate-600 rounded-lg text-white text-sm focus:outline-none focus:border-purple-500 transition-colors cursor-pointer"
-			>
-				<option value="all">All Games</option>
-				<option value="monitored">Monitored</option>
-				<option value="unmonitored">Unmonitored</option>
-				<option value="updates">Has Updates</option>
-			</select>
-		</div>
 		</div>
 
 		<div class="flex items-center gap-2 shrink-0">
-		<button
-			onclick={openAddModal}
-			class="px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-2 whitespace-nowrap"
-		>
-			<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-			</svg>
-			Add Game
-		</button>
+			<button
+				onclick={openAddModal}
+				class="px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-2 whitespace-nowrap"
+			>
+				<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+				</svg>
+				Add Game
+			</button>
 
 		<!-- Alt Speed Mode (Turtle) Toggle -->
 		{#if altSpeedMode !== null}
@@ -808,7 +808,7 @@
 											alt={game.title}
 											class="w-16 h-24 rounded object-cover shrink-0 border border-slate-600 shadow-lg"
 											loading="lazy"
-											onerror={(e) => { 
+											onerror={(e) => {
 												const target = e.currentTarget as HTMLImageElement;
 												target.style.display = 'none';
 												const next = target.nextElementSibling as HTMLElement | null;
@@ -861,8 +861,8 @@
 													<span class="text-slate-300 font-mono">{status.progress}%</span>
 												</div>
 												<div class="h-1.5 w-full bg-slate-700/50 rounded-full overflow-hidden border border-slate-600/30">
-													<div 
-														class="h-full rounded-full transition-all duration-700 ease-out {isDownloading ? 'bg-blue-500 shadow-[0_0_8px_rgba(59,130,246,0.5)] animate-pulse' : isFinished ? 'bg-emerald-500' : 'bg-slate-500'}" 
+													<div
+														class="h-full rounded-full transition-all duration-700 ease-out {isDownloading ? 'bg-blue-500 shadow-[0_0_8px_rgba(59,130,246,0.5)] animate-pulse' : isFinished ? 'bg-emerald-500' : 'bg-slate-500'}"
 														style="width: {status.progress}%"
 													></div>
 												</div>
@@ -1183,8 +1183,8 @@
 				<h3 class="text-xl font-bold text-white">Add Game</h3>
 				<p class="text-sm text-slate-400 mt-1">Add a new game to your library</p>
 			</div>
-			
-			<form 
+
+			<form
 				onsubmit={handleAddGame}
 				class="p-6 space-y-5"
 			>
@@ -1232,7 +1232,7 @@
 							autocomplete="off"
 							class="w-full px-4 py-3 bg-slate-900/50 border border-slate-600/50 rounded-xl text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-purple-500/50 focus:border-transparent transition-all pr-10"
 						/>
-						
+
 						<!-- Status Icon -->
 						<div class="absolute right-3 top-1/2 -translate-y-1/2">
 							{#if isSearching}
@@ -1445,7 +1445,7 @@
 									class="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-lg text-white text-sm pr-10"
 									autocomplete="off"
 								/>
-								
+
 								<!-- Status Icon -->
 								<div class="absolute right-3 top-1/2 -translate-y-1/2">
 									{#if isEditingSearching}
@@ -1550,9 +1550,9 @@
 									for="edit_igdb_id"
 									class="block text-sm font-medium text-slate-300">IGDB ID (Optional)</label
 								>
-								<a 
-									href="https://www.igdb.com/search?q={encodeURIComponent(editGame.cleanTitle || editGame.title)}" 
-									target="_blank" 
+								<a
+									href="https://www.igdb.com/search?q={encodeURIComponent(editGame.cleanTitle || editGame.title)}"
+									target="_blank"
 									rel="noopener"
 									class="text-[10px] text-purple-400 hover:text-purple-300 flex items-center gap-1 transition-colors"
 								>

--- a/src/routes/library/+page.svelte
+++ b/src/routes/library/+page.svelte
@@ -651,8 +651,8 @@
 
 <div class="p-6 space-y-6">
 
-	<div class="flex items-center justify-between gap-4">
-		<h2 class="text-2xl font-bold text-white">Game Library</h2>
+	<div class="flex items-center gap-4">
+		<h2 class="text-2xl font-bold text-white shrink-0">Game Library</h2>
 		
 		<div class="flex items-center gap-3 flex-1 max-w-2xl">
 			<!-- Search Bar -->
@@ -679,7 +679,8 @@
 				<option value="updates">Has Updates</option>
 			</select>
 		</div>
-		
+
+		<div class="flex items-center gap-2 ml-auto shrink-0">
 		<button
 			onclick={() => (showAddModal = true)}
 			class="px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-2 whitespace-nowrap"
@@ -735,6 +736,7 @@
 			{/if}
 			Auto-DL {autoDownloadEnabled ? 'ON' : 'OFF'}
 		</button>
+		</div>
 	</div>
 
 	<!-- Stats -->
@@ -769,7 +771,7 @@
 						<th class="px-4 py-3 text-xs font-medium text-slate-400 uppercase">Status</th>
 						<th class="px-4 py-3 text-xs font-medium text-slate-400 uppercase">Updates</th>
 						<th class="px-4 py-3 text-xs font-medium text-slate-400 uppercase">Links</th>
-						<th class="px-4 py-3 text-xs font-medium text-slate-400 uppercase">AutoDL</th>
+						<th class="px-4 py-3 text-xs font-medium text-slate-400 uppercase whitespace-nowrap w-px">AutoDL</th>
 						<th class="px-4 py-3 text-xs font-medium text-slate-400 uppercase">Actions</th>
 					</tr>
 				</thead>
@@ -1067,7 +1069,7 @@
 								</div>
 							</td>
 							<!-- AutoDL column -->
-							<td class="px-4 py-3">
+							<td class="px-4 py-3 w-px whitespace-nowrap">
 								<div class="flex rounded-lg overflow-hidden border border-slate-600/50 text-[10px] font-medium">
 									<button
 										onclick={() => setGameAutoDownload(game.id, null)}

--- a/src/routes/library/+page.svelte
+++ b/src/routes/library/+page.svelte
@@ -107,6 +107,11 @@
 			if (resp.ok) {
 				const data = await resp.json();
 				autoDownloadEnabled = data.enabled ?? autoDownloadEnabled;
+				if (autoDownloadEnabled) {
+					toastStore.info('AutoDL enabled — eligible games will be downloaded on the next scan.', 'Auto-Download');
+				} else {
+					toastStore.info('AutoDL disabled — releases will appear on the Dashboard for manual selection.', 'Auto-Download');
+				}
 			}
 		} catch { /* ignore */ }
 		autoDownloadToggling = false;
@@ -710,8 +715,8 @@
 			onclick={toggleAutoDownload}
 			disabled={autoDownloadToggling}
 			title={autoDownloadEnabled
-				? 'Auto-Download ON — Best high-tier releases are downloaded automatically. Click to disable.'
-				: 'Auto-Download OFF — Releases are shown on dashboard for manual selection. Click to enable.'}
+				? 'AutoDL ON — Best matching releases are downloaded automatically on each scan. Click to disable.'
+				: 'AutoDL OFF — Releases appear on Dashboard for manual selection. Click to enable. Takes effect on the next scan.'}
 			class="px-3 py-2 text-sm font-medium rounded-lg border transition-all flex items-center gap-2 whitespace-nowrap disabled:opacity-60 disabled:cursor-not-allowed
 				{autoDownloadEnabled
 					? 'bg-emerald-500/20 border-emerald-500/40 text-emerald-400 hover:bg-emerald-500/30'
@@ -1063,22 +1068,25 @@
 							<td class="px-4 py-3">
 								<div class="flex flex-wrap gap-1.5">
 									<!-- Per-game Auto-Download toggle -->
-									<div class="flex rounded-lg overflow-hidden border border-slate-600/50 text-[10px] font-medium shrink-0" title="Auto-Download override for this game">
-										<button
-											onclick={() => setGameAutoDownload(game.id, null)}
-											class="px-2 py-1.5 transition-colors {(perGameAutoDownload[game.id] ?? null) === null ? 'bg-slate-500 text-white' : 'bg-slate-800 text-slate-500 hover:text-slate-300'}"
-											title="Use global auto-download setting"
-										>Global</button>
-										<button
-											onclick={() => setGameAutoDownload(game.id, true)}
-											class="px-2 py-1.5 border-x border-slate-600/50 transition-colors {perGameAutoDownload[game.id] === true ? 'bg-emerald-600 text-white' : 'bg-slate-800 text-slate-500 hover:text-emerald-400'}"
-											title="Always auto-download for this game"
-										>Always</button>
-										<button
-											onclick={() => setGameAutoDownload(game.id, false)}
-											class="px-2 py-1.5 transition-colors {perGameAutoDownload[game.id] === false ? 'bg-red-700 text-white' : 'bg-slate-800 text-slate-500 hover:text-red-400'}"
-											title="Never auto-download for this game"
-										>Never</button>
+									<div class="flex items-center gap-1 shrink-0">
+										<span class="text-[10px] font-semibold text-slate-400 uppercase tracking-wide select-none">AutoDL:</span>
+										<div class="flex rounded-lg overflow-hidden border border-slate-600/50 text-[10px] font-medium">
+											<button
+												onclick={() => setGameAutoDownload(game.id, null)}
+												class="px-2 py-1.5 transition-colors {(perGameAutoDownload[game.id] ?? null) === null ? 'bg-slate-500 text-white' : 'bg-slate-800 text-slate-500 hover:text-slate-300'}"
+												title="Follow the global AutoDL setting (top toolbar)"
+											>Global</button>
+											<button
+												onclick={() => setGameAutoDownload(game.id, true)}
+												class="px-2 py-1.5 border-x border-slate-600/50 transition-colors {perGameAutoDownload[game.id] === true ? 'bg-emerald-600 text-white' : 'bg-slate-800 text-slate-500 hover:text-emerald-400'}"
+												title="Always auto-download this game, regardless of global setting"
+											>Always</button>
+											<button
+												onclick={() => setGameAutoDownload(game.id, false)}
+												class="px-2 py-1.5 transition-colors {perGameAutoDownload[game.id] === false ? 'bg-red-700 text-white' : 'bg-slate-800 text-slate-500 hover:text-red-400'}"
+												title="Never auto-download this game, regardless of global setting"
+											>Never</button>
+										</div>
 									</div>
 									<button
 										onclick={() => (editGameId = game.id)}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -4,6 +4,7 @@
 	import { enhance } from '$app/forms';
 	import { fade, slide } from 'svelte/transition';
 	import { flip } from 'svelte/animate';
+	import { APP_VERSION_LABEL } from '$lib/version.js';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
 
@@ -399,12 +400,12 @@
 						<div class="space-y-1">
 							<span class="text-xs font-semibold text-slate-500 uppercase tracking-wider">Sync Interval</span>
 							<div class="text-sm text-slate-300 font-mono bg-slate-900/50 px-3 py-2 rounded-lg border border-slate-700/50">
-								Every {data.settings.CRON_INTERVAL_MINUTES} minutes
+								Runs once on startup, then every {data.settings.CRON_INTERVAL_MINUTES} minutes
 							</div>
 						</div>
 						<div class="space-y-1">
 							<span class="text-xs font-semibold text-slate-500 uppercase tracking-wider">Version</span>
-							<div class="text-sm text-slate-300 font-mono">v0.1.0</div>
+							<div class="text-sm text-slate-300 font-mono">{APP_VERSION_LABEL}</div>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## Scope
- add the auto-download system with global and per-game controls
- add the notifications schema, APIs, and in-app notification panel
- switch scheduling to startup + true interval execution with overlap protection
- harden auth and sanitize API error responses
- centralize version reporting and align scan/progress cleanup behavior
- persist downloaded torrent metadata and keep only old read notifications during cleanup
- publish `ghcr.io/yakrel/repackarr:beta` from the beta branch while keeping `:latest` on main

## Why this is still draft
- this is a broad beta branch change set touching database schema, UI, scheduler behavior, qBittorrent/Prowlarr flows, release handling, and CI publishing
- it should stay in staging review until manual testing is fully complete

## Validation
- pnpm check
- npx tsx tests/test_parsing.ts
- pnpm build
- manual beta preview smoke test against the live environment (startup scan + scheduled rescan verified)
