### PR TITLE
[codex] Refresh public README and Steam link icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,11 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 [![Docker Image](https://img.shields.io/badge/docker-ghcr.io%2Fyakrel%2Frepackarr-blue?logo=docker)](https://ghcr.io/yakrel/repackarr)
 
-**Repackarr** helps you keep your game repack library up to date. It reads what you already have in qBittorrent, checks Prowlarr for better or newer releases, and lets you either pick updates manually or automate the whole flow.
+**Repackarr** is a self-hosted companion for qBittorrent and Prowlarr that helps keep a game repack library up to date.
 
-## How It Works
+It imports the games you already have in qBittorrent, searches Prowlarr for newer releases, and lets you either review updates manually or let AutoDL handle eligible upgrades.
 
-```
-1. Sync Library      →   Repackarr imports the games you already have in qBittorrent.
-2. Check for Updates →   It keeps looking for newer releases in the background and you can also scan anytime.
-3. Update Your Games →   Review releases on the Dashboard or turn on AutoDL for hands-off upgrades.
-4. Stay Informed     →   Notifications tell you when AutoDL succeeds, fails, or skips a game.
-```
+Repackarr is designed around **RuTracker.org** and **NoNaMe Club (NNM-Club)** release formats. Other Prowlarr indexers may work, but title parsing, version detection, and game matching are best-effort outside those trackers.
 
 ## Screenshots
 
@@ -27,47 +22,73 @@
 
 ## Features
 
-- **Automatic Library Sync**: Pulls in the games you already manage in qBittorrent, so there is no big manual setup.
-- **Smart Version Detection**: Reads version info from torrent titles and tracker pages across the major repack sources.
-- **Automatic Update Checks**: Keeps an eye on your monitored games and looks for newer releases for you.
-- **Auto-Download When You Want It**: Turn AutoDL on for the whole library or fine-tune it per game.
-- **Notification Center**: See right away when an automatic download worked, failed, or was skipped.
-- **Game Covers & Metadata**: Adds artwork and cleaner game info with IGDB support.
-- **One-Click Updates**: Prefer manual control? Send a release to qBittorrent with one click.
-- **Flexible Add Modes**: Choose between “I Want This Game” and “I Already Have It” when adding a title.
-- **Skip & Ignore**: Hide releases you do not want and restore them later from the blacklist.
-- **Scan History**: Review what past syncs and update checks found.
+- **qBittorrent library sync**: Imports games from a dedicated qBittorrent category.
+- **Prowlarr update search**: Checks your configured RuTracker and NNM-Club indexers for newer matching releases.
+- **Manual update review**: Confirm, ignore, skip, or send releases to qBittorrent from the dashboard.
+- **AutoDL support**: Automatically download eligible updates globally or per game.
+- **Per-game controls**: Tune search queries, platform filters, ignored keywords, and AutoDL behavior.
+- **IGDB metadata**: Optional cover art, cleaner titles, and autocomplete support.
+- **Notifications**: See when automatic downloads succeed, fail, or are skipped.
+- **Scan history**: Review recent sync and update checks, including skipped release reasons.
+- **Basic Auth**: Optional username/password protection for the web UI.
 
-## Auto-Download & Notifications
+## How It Works
 
-- Turn **AutoDL** on from the **Library** page when you want Repackarr to grab updates for you.
-- Leave it off if you prefer to review releases on the Dashboard first.
-- You can still override AutoDL for each game:
-  - **Use Global** → inherit the library-wide toggle
-  - **Always** → auto-download updates for this game even if the global toggle is off
-  - **Never** → keep this game manual even if the global toggle is on
-- Notifications in the top bar let you know when Repackarr downloads an update, cannot send one to qBittorrent, or skips a game that is already downloading.
+1. Repackarr reads torrents from your configured qBittorrent category.
+2. It creates a monitored game library from those torrents.
+3. It searches Prowlarr for newer matching releases.
+4. Matching releases appear on the dashboard for review.
+5. If AutoDL is enabled, Repackarr can send the best eligible release to qBittorrent automatically.
 
-## Getting Started (Docker)
+The first full scan runs shortly after startup, then recurring scans run on the configured interval. You can also start a sync or update check from the UI at any time.
 
-### Prerequisites
-1. **qBittorrent**: WebUI must be enabled. Games you want to monitor should be in a dedicated category (default: `games`).
-2. **Prowlarr**: At least one indexer configured. For the best results, **RuTracker.org** and **NoNaMe Club (NNM-Club)** are recommended.
-3. **IGDB** *(Optional but recommended)*: Enables game covers and autocomplete search. Register a free app at the [Twitch Developer Portal](https://dev.twitch.tv/console) to get your credentials.
+## Requirements
 
-### 1. Create Directories
+- **qBittorrent** with WebUI enabled.
+- **Prowlarr** with RuTracker.org and/or NoNaMe Club configured.
+- **Docker Compose** for the recommended setup.
+- **IGDB credentials** are optional, but recommended for covers and autocomplete.
+
+For best results, keep the games you want Repackarr to monitor in a dedicated qBittorrent category. The default category is `games`.
+
+## Docker Compose
+
+Create a folder for Repackarr:
+
 ```bash
-mkdir repackarr && cd repackarr
+mkdir repackarr
+cd repackarr
 mkdir data logs
 ```
 
-### 2. Configure Environment
-```bash
-cp .env.example .env
-# Edit .env with your qBittorrent and Prowlarr details
+Create a `.env` file:
+
+```env
+QBIT_HOST=http://192.168.1.100:8080
+QBIT_USERNAME=admin
+QBIT_PASSWORD=adminadmin
+QBIT_CATEGORY=games
+
+PROWLARR_URL=http://192.168.1.100:9696
+PROWLARR_API_KEY=your_prowlarr_api_key
+
+IGDB_CLIENT_ID=
+IGDB_CLIENT_SECRET=
+
+AUTH_USERNAME=
+AUTH_PASSWORD=
+
+CRON_INTERVAL_MINUTES=360
+STARTUP_SCAN_DELAY_SECONDS=120
+
+DATA_DIR=./data
+LOG_DIR=./logs
 ```
 
-### 3. Docker Compose
+Edit `.env` with your qBittorrent and Prowlarr details.
+
+Use this `docker-compose.yml`:
+
 ```yaml
 services:
   repackarr:
@@ -81,6 +102,8 @@ services:
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
+    environment:
+      - TZ=Europe/Istanbul
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
       interval: 30s
@@ -89,57 +112,68 @@ services:
       start_period: 10s
 ```
 
-### 4. Launch
+Start the container:
+
 ```bash
 docker compose up -d
 ```
-Open `http://your-ip:8090` and hit **Sync Library** to get started.
 
-After startup, Repackarr refreshes your library and begins checking for updates automatically.
+Open `http://your-server-ip:8090` and use **Sync Library** to import your qBittorrent games.
 
 ## Configuration
 
-All connection details are set via environment variables in your `.env` file:
+All core connection settings are configured through `.env`.
 
 | Variable | Default | Description |
-|---|---|---|
-| `QBIT_HOST` | — | qBittorrent WebUI URL (e.g. `http://192.168.1.10:8080`) |
-| `QBIT_USERNAME` | — | qBittorrent username |
-| `QBIT_PASSWORD` | — | qBittorrent password |
-| `QBIT_CATEGORY` | `games` | The qBittorrent category to monitor |
-| `PROWLARR_URL` | — | Prowlarr URL |
-| `PROWLARR_API_KEY` | — | Prowlarr API key |
-| `IGDB_CLIENT_ID` | (None) | *Recommended* — enables covers & autocomplete |
-| `IGDB_CLIENT_SECRET` | (None) | *Recommended* — enables covers & autocomplete |
-| `CRON_INTERVAL_MINUTES` | `360` | How often to scan for updates (in minutes) |
-| `AUTH_USERNAME` | (None) | Enable Basic Auth for the UI |
-| `AUTH_PASSWORD` | (None) | Enable Basic Auth for the UI |
-| `DATA_DIR` | `/app/data` | Where app data is stored. For the bundled Docker setup, set this to `./data` in your `.env`. |
-| `LOG_DIR` | `logs` | Where app logs are written. For the bundled Docker setup, set this to `./logs` in your `.env`. |
+|---|---:|---|
+| `QBIT_HOST` | - | qBittorrent WebUI URL, for example `http://192.168.1.10:8080` |
+| `QBIT_USERNAME` | - | qBittorrent username |
+| `QBIT_PASSWORD` | - | qBittorrent password |
+| `QBIT_CATEGORY` | `games` | qBittorrent category to monitor |
+| `PROWLARR_URL` | - | Prowlarr URL |
+| `PROWLARR_API_KEY` | - | Prowlarr API key |
+| `IGDB_CLIENT_ID` | - | Optional IGDB client ID for covers and autocomplete |
+| `IGDB_CLIENT_SECRET` | - | Optional IGDB client secret |
+| `AUTH_USERNAME` | - | Enables Basic Auth when set with `AUTH_PASSWORD` |
+| `AUTH_PASSWORD` | - | Enables Basic Auth when set with `AUTH_USERNAME` |
+| `CRON_INTERVAL_MINUTES` | `360` | Recurring scan interval, from 5 to 1440 minutes |
+| `STARTUP_SCAN_DELAY_SECONDS` | `120` | Delay before the startup scan, from 0 to 3600 seconds |
+| `DATA_DIR` | `/app/data` | App database location inside the container |
+| `LOG_DIR` | `logs` | Log file location inside the container |
 
-The following controls are managed from the UI:
+With the Docker Compose example above, `DATA_DIR=./data` and `LOG_DIR=./logs` resolve inside the container to the mounted `/app/data` and `/app/logs` folders. The database and logs are stored on your host in `./data` and `./logs`, so they survive container updates.
 
-- **Settings page**
-  - **Ignored Keywords** — releases containing these keywords will be skipped globally.
-  - **Allowed Indexers** — restrict searches to specific Prowlarr indexers.
-  - **Default Platform** — Windows, Linux, or macOS.
-- **Library page**
-  - **Global Auto-Download** — enable or disable automatic downloading for monitored games.
-  - **Per-game Auto-Download** — override the global AutoDL behavior for one title at a time.
-  - **Add Game Mode** — choose between immediate search/download flow or track-only monitoring when adding a game manually.
+The following settings are managed from the web UI:
+
+- Ignored keywords
+- Allowed Prowlarr indexers
+- Default platform
+- Global AutoDL
+- Per-game AutoDL overrides
+- Per-game search queries and filters
+
+## Notes
+
+- Repackarr is tuned for RuTracker.org and NoNaMe Club. Other trackers may need manual search query adjustments and may not parse versions reliably.
+- Prowlarr indexer names in **Allowed Indexers** must match the names shown in Prowlarr.
+- IGDB is optional. Repackarr still works without it, but covers and autocomplete will be limited.
+- AutoDL skips a game if it is already actively downloading and shows a notification instead.
+- The torrent title parser is validated against the included golden dataset in `tests/torrent_examples.json`.
 
 ## Troubleshooting
 
-- **Games not found**: Try adjusting the "Search Query" for that game in the Library page to match how it appears on your indexer.
-- **Indexer not working**: The name in **Allowed Indexers** must match exactly what Prowlarr shows.
-- **Auto-download did not trigger**: Make sure AutoDL is enabled globally or for that specific game and that qBittorrent is reachable. If the game is already downloading, Repackarr will skip it and notify you.
-- **Need more detail?**: Check the log files in `LOG_DIR`.
-- **Database errors on startup**: Fix permissions with `chown -R 1000:1000 ./data`.
-- **Reverse proxy**: Works with Nginx Proxy Manager and Traefik using a standard WebSocket-enabled config.
+- **No games are imported**: Check that qBittorrent WebUI works and your torrents are in the configured category.
+- **No releases are found**: Adjust the game's search query in the Library page and confirm your RuTracker/NNM-Club indexers work in Prowlarr.
+- **Allowed indexer does not match**: Use the exact indexer name shown in Prowlarr.
+- **AutoDL does not run**: Check that AutoDL is enabled globally or for the game, and that qBittorrent is reachable.
+- **Progress does not update behind a reverse proxy**: Make sure response streaming / Server-Sent Events are not buffered for `/api/scan/progress`.
+- **Database permission errors**: Make sure the mounted `data` folder is writable by the container.
+- **Need more detail**: Check the Repackarr log files in the configured `LOG_DIR`.
 
 ## License
 
 GPL v3 License. See [LICENSE](LICENSE) for more information.
 
 ---
-*Repackarr is a tool for managing your own library. Please support game developers whenever possible.*
+
+Repackarr is a tool for managing your own library. Please support game developers whenever possible.

--- a/src/routes/library/+page.svelte
+++ b/src/routes/library/+page.svelte
@@ -1057,15 +1057,18 @@
 											title="Open Steam store page"
 										>
 											<svg class="w-3 h-3" fill="currentColor" viewBox="0 0 24 24">
-												<path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/>
+												<path d="M11.98 0C5.68 0 .51 4.86.02 11.04l6.43 2.66a3.4 3.4 0 0 1 1.91-.59h.19l2.86-4.14v-.06a4.53 4.53 0 1 1 4.42 4.53l-4.07 2.91v.16a3.39 3.39 0 0 1-6.72.66L.44 15.27A12 12 0 1 0 11.98 0ZM7.54 18.21l-1.47-.61c.26.54.71 1 1.31 1.25a2.51 2.51 0 0 0 3.33-1.38 2.5 2.5 0 0 0-1.37-3.33 2.48 2.48 0 0 0-1.88-.03l1.53.63a1.88 1.88 0 1 1-1.45 3.47Zm8.4-6.29a3.02 3.02 0 1 0 0-6.03 3.02 3.02 0 0 0 0 6.03Zm0-.76a2.26 2.26 0 1 1 .01-4.52 2.26 2.26 0 0 1-.01 4.52Z" />
 											</svg>
 											Steam
 										</a>
 									{:else}
 										<span
-											class="inline-flex w-[7.5rem] justify-center items-center px-2 py-1 rounded-lg border border-slate-700/50 bg-slate-900/30 text-slate-600 text-xs font-medium"
+											class="inline-flex w-[7.5rem] justify-center items-center gap-1 px-2 py-1 rounded-lg border border-slate-700/50 bg-slate-900/30 text-slate-600 text-xs font-medium"
 											title="No Steam App ID available"
 										>
+											<svg class="w-3 h-3" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+												<path d="M11.98 0C5.68 0 .51 4.86.02 11.04l6.43 2.66a3.4 3.4 0 0 1 1.91-.59h.19l2.86-4.14v-.06a4.53 4.53 0 1 1 4.42 4.53l-4.07 2.91v.16a3.39 3.39 0 0 1-6.72.66L.44 15.27A12 12 0 1 0 11.98 0ZM7.54 18.21l-1.47-.61c.26.54.71 1 1.31 1.25a2.51 2.51 0 0 0 3.33-1.38 2.5 2.5 0 0 0-1.37-3.33 2.48 2.48 0 0 0-1.88-.03l1.53.63a1.88 1.88 0 1 1-1.45 3.47Zm8.4-6.29a3.02 3.02 0 1 0 0-6.03 3.02 3.02 0 0 0 0 6.03Zm0-.76a2.26 2.26 0 1 1 .01-4.52 2.26 2.26 0 0 1-.01 4.52Z" />
+											</svg>
 											Steam
 										</span>
 									{/if}


### PR DESCRIPTION
## Summary
- Rework the README into a clearer public self-hosted project overview with Docker Compose setup and practical troubleshooting.
- Document that Repackarr is tuned for RuTracker.org and NoNaMe Club release formats, with other Prowlarr indexers treated as best-effort.
- Replace the generic Library Steam button glyph with a Steam-like icon, including the disabled state.

## Validation
- `npx tsx tests/test_parsing.ts`
- `pnpm check`
- `git diff --check`