### PR TITLE
fix: support qBittorrent v5+ 204 response on connection test

### DIFF
--- a/src/routes/api/test/qbit/+server.ts
+++ b/src/routes/api/test/qbit/+server.ts
@@ -20,7 +20,7 @@ export const POST: RequestHandler = async () => {
 			return json({ success: false, message: 'IP banned — too many failed login attempts' });
 		}
 		const text = await resp.text();
-		if (text.trim() === 'Ok.') {
+		if (resp.status === 204 || text.trim() === 'Ok.') {
 			await qbitService.login(true);
 			return json({ success: true, message: 'Connection successful' });
 		}


### PR DESCRIPTION
qBittorrent login check will return a 204 code instead of the "Ok" string, resulting in an "Incorrect Username and Password" error popping up in Repackarr.

This change will allow either return to mark the connection as successful